### PR TITLE
add tests for path and host field overwriting

### DIFF
--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'stud', ['~> 0.0.19']
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-codec-json'
 end
 


### PR DESCRIPTION
Currently when a user uses the json codec with the file input, if the event in the file contains an existing "path" field, the plugin overwrites the existing field with that of the file's path. Just as is done in the "host" field, this fix adds a check to see if a "path" field exists, and if it does, it will leave it be.