### PR TITLE
bump filewatch to 0.6.4

### DIFF
--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '0.1.10'
+  s.version         = '0.1.11'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from files."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'addressable'
-  s.add_runtime_dependency 'filewatch', ['>= 0.6.2', '~> 0.6']
+  s.add_runtime_dependency 'filewatch', ['>= 0.6.4', '~> 0.6']
 
   s.add_development_dependency 'stud', ['~> 0.0.19']
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
force upgrade of filewatch library to 0.6.4 due to https://github.com/jordansissel/ruby-filewatch/issues/58