### PR TITLE
improve sincedb_path argument handling and documentation

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -46,9 +46,10 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
   # How often (in seconds) we expand globs to discover new files to watch.
   config :discover_interval, :validate => :number, :default => 15
 
-  # Where to write the sincedb database (keeps track of the current
-  # position of monitored log files). The default will write
-  # sincedb files to some path matching `$HOME/.sincedb*`
+  # Path of the sincedb database file (keeps track of the current
+  # position of monitored log files) that will be written to disk.
+  # The default will write sincedb files to some path matching `$HOME/.sincedb*`
+  # NOTE: it must be a file path and not a directory path
   config :sincedb_path, :validate => :string
 
   # How often (in seconds) to write a since database with the current position of
@@ -118,6 +119,10 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
 
       @logger.info("No sincedb_path set, generating one based on the file path",
                    :sincedb_path => @sincedb_path, :path => @path)
+    end
+
+    if File.directory?(@sincedb_path)
+      raise ArgumentError.new("sincedb_path must be a file path, not a directory. Received: \"#{@sincedb_path}\"")
     end
 
     @tail_config[:sincedb_path] = @sincedb_path

--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -122,7 +122,7 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
     end
 
     if File.directory?(@sincedb_path)
-      raise ArgumentError.new("sincedb_path must be a file path, not a directory. Received: \"#{@sincedb_path}\"")
+      raise ArgumentError.new("The \"sincedb_path\" argument must point to a file, received a directory: \"#{@sincedb_path}\"")
     end
 
     @tail_config[:sincedb_path] = @sincedb_path

--- a/spec/inputs/file_spec.rb
+++ b/spec/inputs/file_spec.rb
@@ -167,13 +167,17 @@ describe "inputs/file" do
     insist { events[1]["host"] } == "#{Socket.gethostname.force_encoding(Encoding::UTF_8)}"
   end
 
-  context "sincedb_path is an existing directory" do
+  context "when sincedb_path is an existing directory" do
+    let(:tmpfile_path) { Stud::Temporary.pathname }
+    let(:sincedb_path) { Stud::Temporary.directory }
+    subject { LogStash::Inputs::File.new("path" => tmpfile_path, "sincedb_path" => sincedb_path) }
+
+    after :each do
+      FileUtils.rm_rf(sincedb_path)
+    end
+
     it "should raise exception" do
-      tmpfile_path = Stud::Temporary.pathname
-      Stud::Temporary.directory do |sincedb_path|
-        plugin = LogStash::Inputs::File.new("path" => tmpfile_path, "sincedb_path" => sincedb_path)
-        expect { plugin.register }.to raise_error(ArgumentError)
-      end
+      expect { subject.register }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/inputs/file_spec.rb
+++ b/spec/inputs/file_spec.rb
@@ -3,6 +3,7 @@
 require "logstash/devutils/rspec/spec_helper"
 require "tempfile"
 require "stud/temporary"
+require "logstash/inputs/file"
 
 describe "inputs/file" do
 
@@ -164,5 +165,15 @@ describe "inputs/file" do
 
     insist { events[1]["path"] } == "#{tmpfile_path}"
     insist { events[1]["host"] } == "#{Socket.gethostname.force_encoding(Encoding::UTF_8)}"
+  end
+
+  context "sincedb_path is an existing directory" do
+    it "should raise exception" do
+      tmpfile_path = Stud::Temporary.pathname
+      Stud::Temporary.directory do |sincedb_path|
+        plugin = LogStash::Inputs::File.new("path" => tmpfile_path, "sincedb_path" => sincedb_path)
+        expect { plugin.register }.to raise_error(ArgumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
While sincedb_path is meant to be a file path, the current documentation misleads users to define a directory path.

The consequence is an exception and consequently removal of the +x flags of the directory. This patch properly validates the path as a directory and improves the documentation of the setting

Fixes #53