### PR TITLE
use plugin.stop to return from run

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -199,15 +199,10 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
         queue << event
       end
     end
-    finished
   end # def run
 
   public
-  def teardown
-    if @tail
-      @tail.sincedb_write
-      @tail.quit
-      @tail = nil
-    end
-  end # def teardown
+  def stop
+    @tail.quit if @tail # _sincedb_write is called implicitly
+  end
 end # class LogStash::Inputs::File

--- a/spec/inputs/file_spec.rb
+++ b/spec/inputs/file_spec.rb
@@ -5,9 +5,18 @@ require "tempfile"
 require "stud/temporary"
 require "logstash/inputs/file"
 
-describe "inputs/file" do
+describe LogStash::Inputs::File do
 
   delimiter = (LogStash::Environment.windows? ? "\r\n" : "\n")
+
+  it_behaves_like "an interruptible input plugin" do
+    let(:config) do
+      {
+        "path" => Stud::Temporary.pathname,
+        "sincedb_path" => Stud::Temporary.pathname
+      }
+    end
+  end
 
   it "should starts at the end of an existing file" do
     tmpfile_path = Stud::Temporary.pathname


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

resolves #68 