### PR TITLE
Temporary fix to make this plugin re-runnable.

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -186,10 +186,15 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
     @codec = LogStash::Codecs::IdentityMapCodec.new(@codec)
   end # def register
 
-  def run(queue)
+  def begin_tailing
+    stop # if the pipeline restarts this input.
     @tail = FileWatch::Tail.new(@tail_config)
     @tail.logger = @logger
     @path.each { |path| @tail.tail(path) }
+  end
+
+  def run(queue)
+    begin_tailing
     @tail.subscribe do |path, line|
       log_line_received(path, line)
       @codec.decode(line, path) do |event|

--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -221,6 +221,9 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
   end
 
   def stop
-    @tail.quit if @tail # _sincedb_write is called implicitly
+    # in filewatch >= 0.6.7, quit will closes and forget all files
+    # but it will write their last read positions to since_db
+    # beforehand
+    @tail.quit if @tail
   end
 end # class LogStash::Inputs::File

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'addressable'
-  s.add_runtime_dependency 'filewatch', ['>= 0.6.5', '~> 0.6']
+  s.add_runtime_dependency 'filewatch', ['>= 0.6.7', '~> 0.6']
   s.add_runtime_dependency 'logstash-codec-multiline', ['~> 2.0.3']
 
   s.add_development_dependency 'stud', ['~> 0.0.19']

--- a/spec/inputs/file_spec.rb
+++ b/spec/inputs/file_spec.rb
@@ -5,11 +5,18 @@ require "tempfile"
 require "stud/temporary"
 require "logstash/inputs/file"
 
-Thread.abort_on_exception = true
-
 FILE_DELIMITER = LogStash::Environment.windows? ? "\r\n" : "\n"
 
 describe LogStash::Inputs::File do
+
+  before(:all) do
+    @abort_on_exception = Thread.abort_on_exception
+    Thread.abort_on_exception = true
+  end
+
+  after(:all) do
+    Thread.abort_on_exception = @abort_on_exception
+  end
 
   it_behaves_like "an interruptible input plugin" do
     let(:config) do
@@ -192,7 +199,7 @@ describe LogStash::Inputs::File do
     end
   end
 
-  context "when #run is called multiple times" do
+  context "when #run is called multiple times", :unix => true do
     let(:tmpdir_path)  { Stud::Temporary.directory }
     let(:sincedb_path) { Stud::Temporary.pathname }
     let(:file_path)    { "#{tmpdir_path}/a.log" }


### PR DESCRIPTION
NOTES:
- Temp fix until we refactor the begin run rescue retry sequence in core.
- The test that uses lsof to verify file closure is unix only. (thanks @jsvd)
