### PR TITLE
Fixes for #101 and #104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2
+ - Fix for: Filewatch library complains if HOME or SINCEDB_PATH variables are unset.
+   - [Issue #101](https://github.com/logstash-plugins/logstash-input-file/issues/101)
+   - [PR, filewatch 78](https://github.com/jordansissel/ruby-filewatch/pull/78) introduces the fix
+   - [Issue, filewatch 76](https://github.com/jordansissel/ruby-filewatch/issues/76)
+ - Improve documentation on ignore_older and close_older options [#104](https://github.com/logstash-plugins/logstash-input-file/issues/104) Documentation
+
 ## 2.2.1
  - Fix spec failures on CI Linux builds (not seen on local OSX and Linux)
 

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '2.2.1'
+  s.version         = '2.2.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from files."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'addressable'
-  s.add_runtime_dependency 'filewatch', ['>= 0.8.0', '~> 0.8']
+  s.add_runtime_dependency 'filewatch', ['>= 0.8.1', '~> 0.8']
   s.add_runtime_dependency 'logstash-codec-multiline', ['~> 2.0.7']
 
   s.add_development_dependency 'stud', ['~> 0.0.19']

--- a/spec/inputs/file_spec.rb
+++ b/spec/inputs/file_spec.rb
@@ -181,15 +181,11 @@ describe LogStash::Inputs::File do
             expect(events.size).to eq(0)
             File.open(tmpfile_path, "a") { |fd| fd.puts("hello"); fd.puts("world") }
           end
-          .then_after(0.1, "only one event is created, the last line is buffered") do
-            expect(events.size).to eq(1)
-          end
-          .then_after(0.1, "quit") do
+          .then_after(0.25, "quit") do
             subject.stop
           end
+
         subject.run(events)
-        # stop flushes the second event
-        expect(events.size).to eq(2)
 
         event1 = events[0]
         expect(event1).not_to be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,8 +47,11 @@ module FileInput
     def accept(listener)
       @tracer.push [:accept, true]
     end
-    def auto_flush()
+    def auto_flush(*)
       @tracer.push [:auto_flush, true]
+    end
+    def flush(*)
+      @tracer.push [:flush, true]
     end
     def close
       @tracer.push [:close, true]


### PR DESCRIPTION
Use filewatch change from 0.8.1 - change the way Tail.new works the prevent a needless creation of the wrong delegate class

make explicit exit flushing, not to rely on close() side effects.

fix failing specs NOTE auto_flush takes an argument

closes #101
closes #104