### PR TITLE
fix problem with escaping and delimiter

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -182,6 +182,9 @@ class LogStash::Inputs::File < LogStash::Inputs::Base
       :max_open_files => @max_open_files
     }
 
+    # TODO: workaround for https://github.com/elastic/logstash/issues/1645
+    @tail_config[:delimiter] = @tail_config[:delimiter].gsub(/\\r/, "\r").gsub(/\\n/, "\n")
+
     @path.each do |path|
       if Pathname.new(path).relative?
         raise ArgumentError.new("File paths must be absolute, relative path specified: #{path}")


### PR DESCRIPTION
Fix issue https://github.com/logstash-plugins/logstash-input-file/issues/47

As long as https://github.com/elastic/logstash/issues/1645 is not closed, the delimiter column is not usable and useless. Therefore add a workaround to support windows files (read by a linux system), because some people are not able to use current beta / upgrade
