### PR TITLE
Important v4.1.1 Fixes 184 and 185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.1.2
+  - Fix `require winhelper` error in WINDOWS.
+    [Issue #184](https://github.com/logstash-plugins/logstash-input-file/issues/184)
+  - Fix when no delimiter is found in a chunk, the chunk is reread - no forward progress
+    is made in the file.
+    [Issue #185](https://github.com/logstash-plugins/logstash-input-file/issues/185)
+
 ## 4.1.1
   - Fix JAR_VERSION read problem, prevented Logstash from starting.
     [Issue #180](https://github.com/logstash-plugins/logstash-input-file/issues/180)

--- a/lib/filewatch/bootstrap.rb
+++ b/lib/filewatch/bootstrap.rb
@@ -37,7 +37,7 @@ module FileWatch
   require "jruby_file_watch"
 
   if LogStash::Environment.windows?
-    require "winhelper"
+    require_relative "winhelper"
     FileOpener = FileExt
     InodeMixin = WindowsInode
   else

--- a/lib/filewatch/bootstrap.rb
+++ b/lib/filewatch/bootstrap.rb
@@ -53,6 +53,8 @@ module FileWatch
     end
   end
 
+  BufferExtractResult = Struct.new(:lines, :warning, :additional)
+
   class NoSinceDBPathGiven < StandardError; end
 
   # how often (in seconds) we logger.warn a failed file open, per path.

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -5,28 +5,30 @@ module FileWatch module ReadMode module Handlers
     def handle_specifically(watched_file)
       if open_file(watched_file)
         add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
-        # if the `file_chunk_count` * `file_chunk_size` is less than the file size
-        # then this method will be executed multiple times
-        # and the seek is moved to just after a line boundary as recorded in the sincedb
-        # for each run - so we reset the buffer
-        watched_file.reset_buffer
-        watched_file.file_seek(watched_file.bytes_read)
         changed = false
         @settings.file_chunk_count.times do
           begin
-            lines = watched_file.buffer_extract(watched_file.file_read(@settings.file_chunk_size))
-            logger.warn("read_to_eof: no delimiter found in current chunk") if lines.empty?
+            data = watched_file.file_read(@settings.file_chunk_size)
+            lines = watched_file.buffer_extract(data)
+            if lines.empty?
+              log_delimiter_not_found(watched_file, data.bytesize)
+            end
             changed = true
             lines.each do |line|
               watched_file.listener.accept(line)
+              # sincedb position is independent from the watched_file bytes_read
               sincedb_collection.increment(watched_file.sincedb_key, line.bytesize + @settings.delimiter_byte_size)
             end
+            # instead of tracking the bytes_read line by line we need to track by the data read size.
+            # because we initially seek to the bytes_read not the sincedb position
+            watched_file.increment_bytes_read(data.bytesize)
           rescue EOFError
             # flush the buffer now in case there is no final delimiter
             line = watched_file.buffer.flush
             watched_file.listener.accept(line) unless line.empty?
             watched_file.listener.eof
             watched_file.file_close
+            # unset_watched_file will set sincedb_value.position to be watched_file.bytes_read
             sincedb_collection.unset_watched_file(watched_file)
             watched_file.listener.deleted
             watched_file.unwatch
@@ -42,6 +44,23 @@ module FileWatch module ReadMode module Handlers
         end
         sincedb_collection.request_disk_flush if changed
       end
+    end
+
+    private
+
+    def log_delimiter_not_found(watched_file, data_size)
+      warning = "read_to_eof: a delimiter can't be found in current chunk"
+      warning.concat(", maybe there are no more delimiters or the delimiter is incorrect")
+      warning.concat(" or the text before the delimiter, a 'line', is very large")
+      warning.concat(", if this message is logged often try increasing the `file_chunk_size` setting.")
+      log_details = {
+        "delimiter" => @settings.delimiter,
+        "read_position" => watched_file.bytes_read,
+        "bytes_read_count" => data_size,
+        "last_known_file_size" => watched_file.last_stat_size,
+        "file_path" => watched_file.path,
+      }
+      logger.info(warning, log_details)
     end
   end
 end end end

--- a/lib/filewatch/tail_mode/handlers/base.rb
+++ b/lib/filewatch/tail_mode/handlers/base.rb
@@ -42,12 +42,10 @@ module FileWatch module TailMode module Handlers
       @settings.file_chunk_count.times do
         begin
           data = watched_file.file_read(@settings.file_chunk_size)
-          lines = watched_file.buffer_extract(data)
-          if lines.empty?
-            log_delimiter_not_found(watched_file, data.bytesize)
-          end
+          result = watched_file.buffer_extract(data) # expect BufferExtractResult
+          logger.info(result.warning, result.additional) unless result.warning.empty?
           changed = true
-          lines.each do |line|
+          result.lines.each do |line|
             watched_file.listener.accept(line)
             # sincedb position is now independent from the watched_file bytes_read
             sincedb_collection.increment(watched_file.sincedb_key, line.bytesize + @settings.delimiter_byte_size)
@@ -68,21 +66,6 @@ module FileWatch module TailMode module Handlers
         end
       end
       sincedb_collection.request_disk_flush if changed
-    end
-
-    def log_delimiter_not_found(watched_file, data_size)
-      warning = "read_to_eof: a delimiter can't be found in current chunk"
-      warning.concat(", maybe there are no more delimiters or the delimiter is incorrect")
-      warning.concat(" or the text before the delimiter, a 'line', is very large")
-      warning.concat(", if this message is logged often try increasing the `file_chunk_size` setting.")
-      log_details = {
-        "delimiter" => @settings.delimiter,
-        "read_position" => watched_file.bytes_read,
-        "bytes_read_count" => data_size,
-        "last_known_file_size" => watched_file.last_stat_size,
-        "file_path" => watched_file.path,
-      }
-      logger.info(warning, log_details)
     end
 
     def open_file(watched_file)

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "logstash/util/loggable"
 
 module FileWatch
   class WatchedFile

--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -142,7 +142,7 @@ class File < LogStash::Inputs::Base
 
   # When the file input discovers a file that was last modified
   # before the specified timespan in seconds, the file is ignored.
-  # After it's discovery, if an ignored file is modified it is no
+  # After its discovery, if an ignored file is modified it is no
   # longer ignored and any new data is read. By default, this option is
   # disabled. Note this unit is in seconds.
   config :ignore_older, :validate => :number

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.1'
+  s.version         = '4.1.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filewatch/buftok_spec.rb
+++ b/spec/filewatch/buftok_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require_relative 'spec_helper'
 
 describe FileWatch::BufferedTokenizer do

--- a/spec/filewatch/reading_spec.rb
+++ b/spec/filewatch/reading_spec.rb
@@ -3,8 +3,6 @@ require 'stud/temporary'
 require_relative 'spec_helper'
 require 'filewatch/observing_read'
 
-LogStash::Logging::Logger::configure_logging("WARN")
-
 module FileWatch
   describe Watch do
     before(:all) do

--- a/spec/filewatch/reading_spec.rb
+++ b/spec/filewatch/reading_spec.rb
@@ -1,4 +1,4 @@
-
+# encoding: utf-8
 require 'stud/temporary'
 require_relative 'spec_helper'
 require 'filewatch/observing_read'

--- a/spec/filewatch/spec_helper.rb
+++ b/spec/filewatch/spec_helper.rb
@@ -119,3 +119,8 @@ module FileWatch
       @listeners.clear; end
   end
 end
+
+ENV["LOG_AT"].tap do |level|
+  LogStash::Logging::Logger::configure_logging(level) unless level.nil?
+end
+

--- a/spec/filewatch/spec_helper.rb
+++ b/spec/filewatch/spec_helper.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "rspec_sequencing"
 require 'rspec/wait'
 require "logstash/devutils/rspec/spec_helper"

--- a/spec/filewatch/tailing_spec.rb
+++ b/spec/filewatch/tailing_spec.rb
@@ -3,9 +3,6 @@ require 'stud/temporary'
 require_relative 'spec_helper'
 require 'filewatch/observing_tail'
 
-LogStash::Logging::Logger::configure_logging("WARN")
-# LogStash::Logging::Logger::configure_logging("DEBUG")
-
 module FileWatch
   describe Watch do
     before(:all) do

--- a/spec/filewatch/tailing_spec.rb
+++ b/spec/filewatch/tailing_spec.rb
@@ -1,4 +1,4 @@
-
+# encoding: utf-8
 require 'stud/temporary'
 require_relative 'spec_helper'
 require 'filewatch/observing_tail'

--- a/spec/filewatch/watched_file_spec.rb
+++ b/spec/filewatch/watched_file_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'stud/temporary'
 require_relative 'spec_helper'
 

--- a/spec/filewatch/watched_files_collection_spec.rb
+++ b/spec/filewatch/watched_files_collection_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require_relative 'spec_helper'
 
 module FileWatch

--- a/spec/filewatch/winhelper_spec.rb
+++ b/spec/filewatch/winhelper_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "stud/temporary"
 require "fileutils"
 


### PR DESCRIPTION
fix `require winhelper` error in WINDOWS
fix when no delimiter is found in a chunk, the chunk is reread - no forward progress is made in the file.

Last one was more subtle and only occurred when the delimiter was not found in a chunk.

Added tests that failed then passed after the fix.