### PR TITLE
In read mode, request sincedb disk flush on each read loop iteration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.1.3
+  - Fixed `read` mode of regular files sincedb write is requested in each read loop
+    iteration rather than waiting for the end-of-file to be reached. Note: for gz files,
+    the sincedb entry can only be updated at the end of the file as it is not possible
+    to seek into a compressed file and begin reading from that position.
+    [Issue #196](https://github.com/logstash-plugins/logstash-input-file/pull/196)
+
 ## 4.1.2
   - Fix `require winhelper` error in WINDOWS.
     [Issue #184](https://github.com/logstash-plugins/logstash-input-file/issues/184)

--- a/lib/filewatch/observing_read.rb
+++ b/lib/filewatch/observing_read.rb
@@ -18,6 +18,5 @@ module FileWatch
     def build_specific_processor(settings)
       ReadMode::Processor.new(settings)
     end
-
   end
 end

--- a/lib/filewatch/read_mode/handlers/base.rb
+++ b/lib/filewatch/read_mode/handlers/base.rb
@@ -7,10 +7,15 @@ module FileWatch module ReadMode module Handlers
 
     attr_reader :sincedb_collection
 
-    def initialize(sincedb_collection, observer, settings)
+    def initialize(processor, sincedb_collection, observer, settings)
       @settings = settings
+      @processor = processor
       @sincedb_collection = sincedb_collection
       @observer = observer
+    end
+
+    def quit?
+      @processor.watch.quit?
     end
 
     def handle(watched_file)

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -5,13 +5,11 @@ module FileWatch module ReadMode module Handlers
     def handle_specifically(watched_file)
       if open_file(watched_file)
         add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
-        changed = false
         @settings.file_chunk_count.times do
           begin
             data = watched_file.file_read(@settings.file_chunk_size)
             result = watched_file.buffer_extract(data) # expect BufferExtractResult
             logger.info(result.warning, result.additional) unless result.warning.empty?
-            changed = true
             result.lines.each do |line|
               watched_file.listener.accept(line)
               # sincedb position is independent from the watched_file bytes_read
@@ -20,6 +18,7 @@ module FileWatch module ReadMode module Handlers
             # instead of tracking the bytes_read line by line we need to track by the data read size.
             # because we initially seek to the bytes_read not the sincedb position
             watched_file.increment_bytes_read(data.bytesize)
+            sincedb_collection.request_disk_flush
           rescue EOFError
             # flush the buffer now in case there is no final delimiter
             line = watched_file.buffer.flush
@@ -28,6 +27,9 @@ module FileWatch module ReadMode module Handlers
             watched_file.file_close
             # unset_watched_file will set sincedb_value.position to be watched_file.bytes_read
             sincedb_collection.unset_watched_file(watched_file)
+            # we know we're done, we should not wait until the discovery of a
+            # new file (or LS shutdown) to write out the sincedb
+            sincedb_collection.immediate_write
             watched_file.listener.deleted
             watched_file.unwatch
             break
@@ -40,7 +42,6 @@ module FileWatch module ReadMode module Handlers
             break
           end
         end
-        sincedb_collection.request_disk_flush if changed
       end
     end
   end

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -6,6 +6,7 @@ module FileWatch module ReadMode module Handlers
       if open_file(watched_file)
         add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
         @settings.file_chunk_count.times do
+          break if quit?
           begin
             data = watched_file.file_read(@settings.file_chunk_size)
             result = watched_file.buffer_extract(data) # expect BufferExtractResult

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -28,9 +28,6 @@ module FileWatch module ReadMode module Handlers
             watched_file.file_close
             # unset_watched_file will set sincedb_value.position to be watched_file.bytes_read
             sincedb_collection.unset_watched_file(watched_file)
-            # we know we're done, we should not wait until the discovery of a
-            # new file (or LS shutdown) to write out the sincedb
-            sincedb_collection.immediate_write
             watched_file.listener.deleted
             watched_file.unwatch
             break

--- a/lib/filewatch/read_mode/handlers/read_zip_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_zip_file.rb
@@ -30,8 +30,11 @@ module FileWatch module ReadMode module Handlers
         logger.error("Cannot decompress the gzip file at path: #{watched_file.path}")
         watched_file.listener.error
       else
-        sincedb_collection.store_last_read(watched_file.sincedb_key, watched_file.last_stat_size)
-        sincedb_collection.request_disk_flush
+        watched_file.update_bytes_read(watched_file.last_stat_size)
+        sincedb_collection.unset_watched_file(watched_file)
+        # we know we're done, we should not wait until the discovery of a
+        # new file (or LS shutdown) to write out the sincedb
+        sincedb_collection.immediate_write
         watched_file.listener.deleted
         watched_file.unwatch
       ensure

--- a/lib/filewatch/read_mode/handlers/read_zip_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_zip_file.rb
@@ -33,9 +33,6 @@ module FileWatch module ReadMode module Handlers
       else
         watched_file.update_bytes_read(watched_file.last_stat_size)
         sincedb_collection.unset_watched_file(watched_file)
-        # we know we're done, we should not wait until the discovery of a
-        # new file (or LS shutdown) to write out the sincedb
-        sincedb_collection.immediate_write
         watched_file.listener.deleted
         watched_file.unwatch
       ensure

--- a/lib/filewatch/read_mode/handlers/read_zip_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_zip_file.rb
@@ -13,10 +13,6 @@ module FileWatch module ReadMode module Handlers
       add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
       # can't really stripe read a zip file, its all or nothing.
       watched_file.listener.opened
-      # what do we do about quit when we have just begun reading the zipped file (e.g. pipeline reloading)
-      # should we track lines read in the sincedb and
-      # fast forward through the lines until we reach unseen content?
-      # meaning that we can quit in the middle of a zip file
       begin
         file_stream = FileInputStream.new(watched_file.path)
         gzip_stream = GZIPInputStream.new(file_stream)
@@ -24,6 +20,11 @@ module FileWatch module ReadMode module Handlers
         buffered = BufferedReader.new(decoder)
         while (line = buffered.readLine(false))
           watched_file.listener.accept(line)
+          # can't quit, if we did then we would incorrectly write a 'completed' sincedb entry
+          # what do we do about quit when we have just begun reading the zipped file (e.g. pipeline reloading)
+          # should we track lines read in the sincedb and
+          # fast forward through the lines until we reach unseen content?
+          # meaning that we can quit in the middle of a zip file
         end
         watched_file.listener.eof
       rescue ZipException => e

--- a/lib/filewatch/read_mode/processor.rb
+++ b/lib/filewatch/read_mode/processor.rb
@@ -25,8 +25,10 @@ module FileWatch module ReadMode
     end
 
     def initialize_handlers(sincedb_collection, observer)
-      @read_file = Handlers::ReadFile.new(sincedb_collection, observer, @settings)
-      @read_zip_file = Handlers::ReadZipFile.new(sincedb_collection, observer, @settings)
+      # we deviate from the tail mode handler initialization here
+      # by adding a reference to self so we can read the quit flag during a (depth first) read loop
+      @read_file = Handlers::ReadFile.new(self, sincedb_collection, observer, @settings)
+      @read_zip_file = Handlers::ReadZipFile.new(self, sincedb_collection, observer, @settings)
     end
 
     def read_file(watched_file)

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -51,6 +51,7 @@ module FileWatch
       until quit?
         iterate_on_state
         break if quit?
+        sincedb_collection.write_if_requested
         glob += 1
         if glob == interval
           discover

--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -316,6 +316,7 @@ class File < LogStash::Inputs::Base
     start_processing
     @queue = queue
     @watcher.subscribe(self) # halts here until quit is called
+    # last action of the subscribe call is to write the sincedb
     exit_flush
   end # def run
 
@@ -338,9 +339,6 @@ class File < LogStash::Inputs::Base
   end
 
   def stop
-    # in filewatch >= 0.6.7, quit will closes and forget all files
-    # but it will write their last read positions to since_db
-    # beforehand
     if @watcher
       @codec.close
       @watcher.quit

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.2'
+  s.version         = '4.1.3'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filewatch/read_mode_handlers_read_file_spec.rb
+++ b/spec/filewatch/read_mode_handlers_read_file_spec.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+require_relative 'spec_helper'
+
+module FileWatch
+  describe ReadMode::Handlers::ReadFile do
+    let(:settings) do
+      Settings.from_options(
+        :sincedb_write_interval => 0,
+        :sincedb_path => File::NULL
+      )
+    end
+    let(:observer) { TestObserver.new }
+    let(:sdb_collection) { SincedbCollection.new(settings) }
+    let(:directory) { Pathname.new(FIXTURE_DIR) }
+    let(:pathname) { directory.join('uncompressed.log') }
+    let(:watched_file) { WatchedFile.new(pathname, pathname.stat, settings) }
+    let(:read_file_handler) { described_class.new(sdb_collection, observer, settings) }
+    let(:expected_siincedb_write_call_count) { 3 }
+    let(:file) { DummyFileReader.new(settings.file_chunk_size, expected_siincedb_write_call_count - 1) }
+
+    context "simulate reading a 64KB file with a default chunk size of 32KB and a zero sincedb write interval" do
+      it "writes to the sincedb file exactly 3 times" do
+        allow(FileOpener).to receive(:open).with(watched_file.path).and_return(file)
+        expect(sdb_collection).to receive(:sincedb_write).exactly(expected_siincedb_write_call_count).times
+        watched_file.activate
+        read_file_handler.handle(watched_file)
+      end
+    end
+  end
+end

--- a/spec/filewatch/read_mode_handlers_read_file_spec.rb
+++ b/spec/filewatch/read_mode_handlers_read_file_spec.rb
@@ -14,14 +14,13 @@ module FileWatch
     let(:pathname) { directory.join('uncompressed.log') }
     let(:watched_file) { WatchedFile.new(pathname, pathname.stat, settings) }
     let(:processor) { ReadMode::Processor.new(settings).add_watch(watch) }
-    let(:expected_sincedb_write_call_count) { 3 }
-    let(:file) { DummyFileReader.new(settings.file_chunk_size, expected_sincedb_write_call_count - 1) }
+    let(:file) { DummyFileReader.new(settings.file_chunk_size, 2) }
 
     context "simulate reading a 64KB file with a default chunk size of 32KB and a zero sincedb write interval" do
       let(:watch) { double("watch", :quit? => false) }
-      it "calls 'sincedb_write' exactly 3 times" do
+      it "calls 'sincedb_write' exactly 2 times" do
         allow(FileOpener).to receive(:open).with(watched_file.path).and_return(file)
-        expect(sdb_collection).to receive(:sincedb_write).exactly(expected_sincedb_write_call_count).times
+        expect(sdb_collection).to receive(:sincedb_write).exactly(2).times
         watched_file.activate
         processor.initialize_handlers(sdb_collection, TestObserver.new)
         processor.read_file(watched_file)

--- a/spec/filewatch/read_mode_handlers_read_file_spec.rb
+++ b/spec/filewatch/read_mode_handlers_read_file_spec.rb
@@ -9,21 +9,32 @@ module FileWatch
         :sincedb_path => File::NULL
       )
     end
-    let(:observer) { TestObserver.new }
     let(:sdb_collection) { SincedbCollection.new(settings) }
     let(:directory) { Pathname.new(FIXTURE_DIR) }
     let(:pathname) { directory.join('uncompressed.log') }
     let(:watched_file) { WatchedFile.new(pathname, pathname.stat, settings) }
-    let(:read_file_handler) { described_class.new(sdb_collection, observer, settings) }
-    let(:expected_siincedb_write_call_count) { 3 }
-    let(:file) { DummyFileReader.new(settings.file_chunk_size, expected_siincedb_write_call_count - 1) }
+    let(:processor) { ReadMode::Processor.new(settings).add_watch(watch) }
+    let(:expected_sincedb_write_call_count) { 3 }
+    let(:file) { DummyFileReader.new(settings.file_chunk_size, expected_sincedb_write_call_count - 1) }
 
     context "simulate reading a 64KB file with a default chunk size of 32KB and a zero sincedb write interval" do
-      it "writes to the sincedb file exactly 3 times" do
+      let(:watch) { double("watch", :quit? => false) }
+      it "calls 'sincedb_write' exactly 3 times" do
         allow(FileOpener).to receive(:open).with(watched_file.path).and_return(file)
-        expect(sdb_collection).to receive(:sincedb_write).exactly(expected_siincedb_write_call_count).times
+        expect(sdb_collection).to receive(:sincedb_write).exactly(expected_sincedb_write_call_count).times
         watched_file.activate
-        read_file_handler.handle(watched_file)
+        processor.initialize_handlers(sdb_collection, TestObserver.new)
+        processor.read_file(watched_file)
+      end
+    end
+
+    context "simulate reading a 64KB file with a default chunk size of 32KB and a zero sincedb write interval" do
+      let(:watch) { double("watch", :quit? => true) }
+      it "calls 'sincedb_write' exactly 0 times as shutdown is in progress" do
+        expect(sdb_collection).to receive(:sincedb_write).exactly(0).times
+        watched_file.activate
+        processor.initialize_handlers(sdb_collection, TestObserver.new)
+        processor.read_file(watched_file)
       end
     end
   end

--- a/spec/filewatch/spec_helper.rb
+++ b/spec/filewatch/spec_helper.rb
@@ -28,6 +28,32 @@ require 'filewatch/bootstrap'
 
 module FileWatch
 
+  class DummyFileReader
+    def initialize(read_size, iterations)
+      @read_size = read_size
+      @iterations = iterations
+      @closed = false
+      @accumulated = 0
+    end
+    def file_seek(*)
+    end
+    def close()
+      @closed = true
+    end
+    def closed?
+      @closed
+    end
+    def sysread(amount)
+      @accumulated += amount
+      if @accumulated > @read_size * @iterations
+        raise EOFError.new
+      end
+      string = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde\n"
+      multiplier = amount / string.length
+      string * multiplier
+    end
+  end
+
   FIXTURE_DIR = File.join('spec', 'fixtures')
 
   def self.make_file_older(path, seconds)

--- a/spec/filewatch/tailing_spec.rb
+++ b/spec/filewatch/tailing_spec.rb
@@ -76,7 +76,7 @@ module FileWatch
 
       context "when close_older is set" do
         let(:wait_before_quit) { 0.8 }
-        let(:opts) { super.merge(:close_older => 0.2, :max_active => 1, :stat_interval => 0.1) }
+        let(:opts) { super.merge(:close_older => 0.15, :max_active => 1, :stat_interval => 0.1) }
         it "opens both files" do
           actions.activate
           tailing.watch_this(watch_dir)


### PR DESCRIPTION
The actual write occurs at the `sincedb_write interval`.

Note: the chunk size vs the events-per-second affect how often a request is made., e.g. a large chunk size (1MB), lines of say 128 bytes and 256 events/s means each iteration takes 32 seconds, and an eps of 32768 takes 250 ms.
With the default chunk size of 32768 bytes and an average line size of 128 bytes a pipeline running at 256 events/s will iterate every 1 second - but with a 32768 event/s the loop takes 7.8125 ms or 128 noop calls to `request_disk_flush` every second.

Fixes #195
