### PR TITLE
WIP: Better support for NFS, step 1

### DIFF
--- a/lib/filewatch/bootstrap.rb
+++ b/lib/filewatch/bootstrap.rb
@@ -42,6 +42,7 @@ module FileWatch
   end
 
   BufferExtractResult = Struct.new(:lines, :warning, :additional)
+  LoopControlResult = Struct.new(:count, :size, :more)
 
   class NoSinceDBPathGiven < StandardError; end
 

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -5,42 +5,51 @@ module FileWatch module ReadMode module Handlers
     def handle_specifically(watched_file)
       if open_file(watched_file)
         add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
-        changed = false
-        logger.trace("reading...", "amount" => watched_file.read_bytesize_description, "filename" => watched_file.filename)
-        watched_file.read_loop_count.times do
+        loop do
           break if quit?
-          begin
-            # expect BufferExtractResult
-            result = watched_file.read_extract_lines
-            # read_extract_lines will increment bytes_read
-            logger.trace(result.warning, result.additional) unless result.warning.empty?
-            changed = true
-            result.lines.each do |line|
-              watched_file.listener.accept(line)
-              # sincedb position is independent from the watched_file bytes_read
-              sincedb_collection.increment(watched_file.sincedb_key, line.bytesize + @settings.delimiter_byte_size)
-            end
-            sincedb_collection.request_disk_flush
-          rescue EOFError
-            # flush the buffer now in case there is no final delimiter
-            line = watched_file.buffer.flush
-            watched_file.listener.accept(line) unless line.empty?
-            watched_file.listener.eof
-            watched_file.file_close
-            key = watched_file.sincedb_key
-            sincedb_collection.reading_completed(key)
-            sincedb_collection.clear_watched_file(key)
-            watched_file.listener.deleted
-            watched_file.unwatch
-            break
-          rescue Errno::EWOULDBLOCK, Errno::EINTR
-            watched_file.listener.error
-            break
-          rescue => e
-            logger.error("read_to_eof: general error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
-            watched_file.listener.error
-            break
+          loop_control = watched_file.loop_control_adjusted_for_stat_size
+          controlled_read(watched_file, loop_control)
+          sincedb_collection.request_disk_flush
+          break unless loop_control.more
+        end
+        if watched_file.all_read?
+          # flush the buffer now in case there is no final delimiter
+          line = watched_file.buffer.flush
+          watched_file.listener.accept(line) unless line.empty?
+          watched_file.listener.eof
+          watched_file.file_close
+          key = watched_file.sincedb_key
+          sincedb_collection.reading_completed(key)
+          sincedb_collection.clear_watched_file(key)
+          watched_file.listener.deleted
+          watched_file.unwatch
+        end
+      end
+    end
+
+    def controlled_read(watched_file, loop_control)
+      logger.trace("reading...", "iterations" => loop_control.count, "amount" => loop_control.size, "filename" => watched_file.filename)
+      loop_control.count.times do
+        begin
+          result = watched_file.read_extract_lines(loop_control.size) # expect BufferExtractResult
+          logger.info(result.warning, result.additional) unless result.warning.empty?
+          result.lines.each do |line|
+            watched_file.listener.accept(line)
+            # sincedb position is independent from the watched_file bytes_read
+            delta = line.bytesize + @settings.delimiter_byte_size
+            sincedb_collection.increment(watched_file.sincedb_key, delta)
           end
+        rescue EOFError
+          logger.error("controlled_read: eof error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
+          break
+        rescue Errno::EWOULDBLOCK, Errno::EINTR
+          logger.error("controlled_read: block or interrupt error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
+          watched_file.listener.error
+          break
+        rescue => e
+          logger.error("controlled_read: general error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
+          watched_file.listener.error
+          break
         end
       end
     end

--- a/lib/filewatch/tail_mode/handlers/grow.rb
+++ b/lib/filewatch/tail_mode/handlers/grow.rb
@@ -4,7 +4,11 @@ module FileWatch module TailMode module Handlers
   class Grow < Base
     def handle_specifically(watched_file)
       watched_file.file_seek(watched_file.bytes_read)
-      read_to_eof(watched_file)
+      loop do
+        loop_control = watched_file.loop_control_adjusted_for_stat_size
+        controlled_read(watched_file, loop_control)
+        break unless loop_control.more
+      end
     end
   end
 end end end

--- a/lib/filewatch/tail_mode/handlers/shrink.rb
+++ b/lib/filewatch/tail_mode/handlers/shrink.rb
@@ -3,10 +3,13 @@
 module FileWatch module TailMode module Handlers
   class Shrink < Base
     def handle_specifically(watched_file)
-      sdbv = add_or_update_sincedb_collection(watched_file)
+      add_or_update_sincedb_collection(watched_file)
       watched_file.file_seek(watched_file.bytes_read)
-      read_to_eof(watched_file)
-      logger.trace("handle_specifically: after read_to_eof", "watched file" => watched_file.details, "sincedb value" => sdbv)
+      loop do
+        loop_control = watched_file.loop_control_adjusted_for_stat_size
+        controlled_read(watched_file, loop_control)
+        break unless loop_control.more
+      end
     end
 
     def update_existing_specifically(watched_file, sincedb_value)

--- a/lib/filewatch/tail_mode/processor.rb
+++ b/lib/filewatch/tail_mode/processor.rb
@@ -155,9 +155,9 @@ module FileWatch module TailMode
             # we need to keep reading the open file, if we close it we lose it because the path is now pointing at a different file.
             logger.trace(">>> Rotation In Progress - inode change detected and original content is not fully read, reading all", "watched_file details" => watched_file.details)
             # need to fully read open file while we can
-            watched_file.set_depth_first_read_loop
+            watched_file.set_maximum_read_loop
             grow(watched_file)
-            watched_file.set_user_defined_read_loop
+            watched_file.set_standard_read_loop
           else
             logger.warn(">>> Rotation In Progress - inode change detected and original content is not fully read, file is closed and path points to new content", "watched_file details" => watched_file.details)
           end

--- a/spec/filewatch/read_mode_handlers_read_file_spec.rb
+++ b/spec/filewatch/read_mode_handlers_read_file_spec.rb
@@ -20,7 +20,7 @@ module FileWatch
       let(:watch) { double("watch", :quit? => false) }
       it "calls 'sincedb_write' exactly 2 times" do
         allow(FileOpener).to receive(:open).with(watched_file.path).and_return(file)
-        expect(sdb_collection).to receive(:sincedb_write).exactly(2).times
+        expect(sdb_collection).to receive(:sincedb_write).exactly(1).times
         watched_file.activate
         processor.initialize_handlers(sdb_collection, TestObserver.new)
         processor.read_file(watched_file)


### PR DESCRIPTION
Step 1
Change the `read to EOF` mechanism to `read to current size`.
Testing on cloud instances with master and this branch.
If testing is successful, then I will port this to filebeat

Future:
Step 2
Allow users to select the sincedb key type from `inode-major-minor` or `path`

Step 3
Add support for fingerprinting.
Add `fingerprint` to the sincedb key type choices.