### PR TITLE
Changed string_duration anchor from hardcoded to asciidoc ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.5
+  - Fixed text anchor by changing it from hardcoded to asciidoc reference to
+    work in versioned plugin reference
+
 ## 4.1.4
   - Fixed a regression where files discovered after first discovery were not
     always read from the beginning. Applies to tail mode only.
@@ -8,6 +12,7 @@
     was possible to read into memory allocated but not filled with data resulting
     in ASCII NUL (0) bytes in the message field. Now, files are read up to the
     size as given by the remote filesystem client. Applies to tail and read modes.
+    
 ## 4.1.3
   - Fixed `read` mode of regular files sincedb write is requested in each read loop
     iteration rather than waiting for the end-of-file to be reached. Note: for gz files,

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -159,12 +159,12 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [NOTE]
 Duration settings can be specified in text form e.g. "250 ms", this string will be converted into
 decimal seconds. There are quite a few supported natural and abbreviated durations,
-see <<string_duration,string duration>> for the details.
+see <<plugins-{type}s-{plugin}-string_duration,string_duration>> for the details.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-close_older>> |<<number,number>> or <<string_duration,string duration>>|No
+| <<plugins-{type}s-{plugin}-close_older>> |<<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>|No
 | <<plugins-{type}s-{plugin}-delimiter>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-discover_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-exclude>> |<<array,array>>|No
@@ -174,15 +174,15 @@ see <<string_duration,string duration>> for the details.
 | <<plugins-{type}s-{plugin}-file_completed_log_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-file_sort_by>> |<<string,string>>, one of `["last_modified", "path"]`|No
 | <<plugins-{type}s-{plugin}-file_sort_direction>> |<<string,string>>, one of `["asc", "desc"]`|No
-| <<plugins-{type}s-{plugin}-ignore_older>> |<<number,number>> or <<string_duration,string duration>>|No
+| <<plugins-{type}s-{plugin}-ignore_older>> |<<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>|No
 | <<plugins-{type}s-{plugin}-max_open_files>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-mode>> |<<string,string>>, one of `["tail", "read"]`|No
 | <<plugins-{type}s-{plugin}-path>> |<<array,array>>|Yes
-| <<plugins-{type}s-{plugin}-sincedb_clean_after>> |<<number,number>> or <<string_duration,string duration>>|No
+| <<plugins-{type}s-{plugin}-sincedb_clean_after>> |<<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>|No
 | <<plugins-{type}s-{plugin}-sincedb_path>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-sincedb_write_interval>> |<<number,number>> or <<string_duration,string duration>>|No
+| <<plugins-{type}s-{plugin}-sincedb_write_interval>> |<<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>|No
 | <<plugins-{type}s-{plugin}-start_position>> |<<string,string>>, one of `["beginning", "end"]`|No
-| <<plugins-{type}s-{plugin}-stat_interval>> |<<number,number>> or <<string_duration,string duration>>|No
+| <<plugins-{type}s-{plugin}-stat_interval>> |<<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -193,7 +193,7 @@ input plugins.
 [id="plugins-{type}s-{plugin}-close_older"]
 ===== `close_older`
 
-  * Value type is <<number,number>> or <<string_duration,string duration>>
+  * Value type is <<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>
   * Default value is `"1 hour"`
 
 The file input closes any files that were last read the specified
@@ -311,7 +311,7 @@ If you use special naming conventions for the file full paths then perhaps
 [id="plugins-{type}s-{plugin}-ignore_older"]
 ===== `ignore_older`
 
-  * Value type is <<number,number>> or <<string_duration,string duration>>
+  * Value type is <<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>
   * There is no default value for this setting.
 
 When the file input discovers a file that was last modified
@@ -371,7 +371,7 @@ on the {logstash-ref}/configuration-file-structure.html#array[Logstash configura
 [id="plugins-{type}s-{plugin}-sincedb_clean_after"]
 ===== `sincedb_clean_after`
 
-  * Value type is <<number,number>> or <<string_duration,string duration>>
+  * Value type is <<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>
   * The default value for this setting is "2 weeks".
   * If a number is specified then it is interpreted as *days* and can be decimal e.g. 0.5 is 12 hours.
 
@@ -395,7 +395,7 @@ NOTE: it must be a file path and not a directory path
 [id="plugins-{type}s-{plugin}-sincedb_write_interval"]
 ===== `sincedb_write_interval`
 
-  * Value type is <<number,number>> or <<string_duration,string duration>>
+  * Value type is <<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>
   * Default value is `"15 seconds"`
 
 How often (in seconds) to write a since database with the current position of
@@ -421,7 +421,7 @@ position recorded in the sincedb file will be used.
 [id="plugins-{type}s-{plugin}-stat_interval"]
 ===== `stat_interval`
 
-  * Value type is <<number,number>> or <<string_duration,string duration>>
+  * Value type is <<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>
   * Default value is `"1 second"`
 
 How often (in seconds) we stat files to see if they have been modified.
@@ -438,9 +438,8 @@ the pipeline is congested. So the overall loop time is a combination of the
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:default_codec!:
 
-[id="string_duration"]
+[id="plugins-{type}s-{plugin}-string_duration"]
 // Move this to the includes when we make string durations available generally.
 ==== String Durations
 
@@ -474,3 +473,4 @@ Supported values: `us` `usec` `usecs`, e.g. "600 us", "800 usec", "900 usecs"
 [NOTE]
 `micro` `micros` and `microseconds` are not supported
 
+:default_codec!:

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.4'
+  s.version         = '4.1.5'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Text anchors in plugin docs must use asciidoc references instead of hardcoding to work in the Versioned Plugin Reference.  Hardcoding works the first time, but throws "already in use" on subsequent builds. 

Changed `[id="string_duration"]` and associated references to `[id="plugins-{type}s-{plugin}-string_duration"]`
