### PR TITLE
Rescue ENOENT when discoverer stats a discovered file and its missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.6
+  - Fixed Errno::ENOENT exception in Discoverer. [Issue #204](https://github.com/logstash-plugins/logstash-input-file/issues/204)
+
 ## 4.1.5
   - Fixed text anchor by changing it from hardcoded to asciidoc reference to
     work in versioned plugin reference

--- a/lib/filewatch/discoverer.rb
+++ b/lib/filewatch/discoverer.rb
@@ -63,8 +63,13 @@ module FileWatch
         new_discovery = false
         watched_file = @watched_files_collection.watched_file_by_path(file)
         if watched_file.nil?
+          begin
+            path_stat = PathStatClass.new(pathname)
+          rescue Errno::ENOENT
+            next
+          end
+          watched_file = WatchedFile.new(pathname, path_stat, @settings)
           new_discovery = true
-          watched_file = WatchedFile.new(pathname, PathStatClass.new(pathname), @settings)
         end
         # if it already unwatched or its excluded then we can skip
         next if watched_file.unwatched? || can_exclude?(watched_file, new_discovery)

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.5'
+  s.version         = '4.1.6'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This is hard to create a meaningful test for this.
The async `rm` call will have to occur at exactly the right point between a file being discovered and it being deleted.

This patch has been confirmed as a fix by a user (Elastic SDH link in issue 204)

Fixes #204

