### PR TITLE
Read + Tail modes, fix endless outer loop when inner loop gets an error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.8
+  - Fixed problem in tail and read modes where the read loop could get stuck if an IO error occurs in the loop.
+    The file appears to be being read but it is not, suspected with file truncation schemes.
+    [Issue #205](https://github.com/logstash-plugins/logstash-input-file/issues/205)
+
 ## 4.1.7
   - Fixed problem in rotation handling where the target file being rotated was
   subjected to the start_position setting when it must always start from the beginning.

--- a/lib/filewatch/bootstrap.rb
+++ b/lib/filewatch/bootstrap.rb
@@ -51,7 +51,7 @@ module FileWatch
       @read_error_detected = false
     end
 
-    def detect_read_error
+    def flag_read_error
       @read_error_detected = true
     end
 

--- a/lib/filewatch/bootstrap.rb
+++ b/lib/filewatch/bootstrap.rb
@@ -42,7 +42,23 @@ module FileWatch
   end
 
   BufferExtractResult = Struct.new(:lines, :warning, :additional)
-  LoopControlResult = Struct.new(:count, :size, :more)
+
+  class LoopControlResult
+    attr_reader :count, :size, :more
+
+    def initialize(count, size, more)
+      @count, @size, @more = count, size, more
+      @read_error_detected = false
+    end
+
+    def detect_read_error
+      @read_error_detected = true
+    end
+
+    def keep_looping?
+      !@read_error_detected && @more
+    end
+  end
 
   class NoSinceDBPathGiven < StandardError; end
 

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -42,17 +42,17 @@ module FileWatch module ReadMode module Handlers
           end
         rescue EOFError
           logger.error("controlled_read: eof error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
-          loop_control.detect_read_error
+          loop_control.flag_read_error
           break
         rescue Errno::EWOULDBLOCK, Errno::EINTR
           logger.error("controlled_read: block or interrupt error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
           watched_file.listener.error
-          loop_control.detect_read_error
+          loop_control.flag_read_error
           break
         rescue => e
           logger.error("controlled_read: general error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
           watched_file.listener.error
-          loop_control.detect_read_error
+          loop_control.flag_read_error
           break
         end
       end

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -10,7 +10,7 @@ module FileWatch module ReadMode module Handlers
           loop_control = watched_file.loop_control_adjusted_for_stat_size
           controlled_read(watched_file, loop_control)
           sincedb_collection.request_disk_flush
-          break unless loop_control.more
+          break unless loop_control.keep_looping?
         end
         if watched_file.all_read?
           # flush the buffer now in case there is no final delimiter
@@ -42,14 +42,17 @@ module FileWatch module ReadMode module Handlers
           end
         rescue EOFError
           logger.error("controlled_read: eof error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
+          loop_control.detect_read_error
           break
         rescue Errno::EWOULDBLOCK, Errno::EINTR
           logger.error("controlled_read: block or interrupt error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
           watched_file.listener.error
+          loop_control.detect_read_error
           break
         rescue => e
           logger.error("controlled_read: general error reading file", "path" => watched_file.path, "error" => e.inspect, "backtrace" => e.backtrace.take(8))
           watched_file.listener.error
+          loop_control.detect_read_error
           break
         end
       end

--- a/lib/filewatch/tail_mode/handlers/base.rb
+++ b/lib/filewatch/tail_mode/handlers/base.rb
@@ -59,16 +59,16 @@ module FileWatch module TailMode module Handlers
           end
         rescue EOFError
           # it only makes sense to signal EOF in "read" mode not "tail"
-          loop_control.detect_read_error
+          loop_control.flag_read_error
           break
         rescue Errno::EWOULDBLOCK, Errno::EINTR
           watched_file.listener.error
-          loop_control.detect_read_error
+          loop_control.flag_read_error
           break
         rescue => e
           logger.error("read_to_eof: general error reading #{watched_file.path}", "error" => e.inspect, "backtrace" => e.backtrace.take(4))
           watched_file.listener.error
-          loop_control.detect_read_error
+          loop_control.flag_read_error
           break
         end
       end

--- a/lib/filewatch/tail_mode/handlers/base.rb
+++ b/lib/filewatch/tail_mode/handlers/base.rb
@@ -59,13 +59,16 @@ module FileWatch module TailMode module Handlers
           end
         rescue EOFError
           # it only makes sense to signal EOF in "read" mode not "tail"
+          loop_control.detect_read_error
           break
         rescue Errno::EWOULDBLOCK, Errno::EINTR
           watched_file.listener.error
+          loop_control.detect_read_error
           break
         rescue => e
           logger.error("read_to_eof: general error reading #{watched_file.path}", "error" => e.inspect, "backtrace" => e.backtrace.take(4))
           watched_file.listener.error
+          loop_control.detect_read_error
           break
         end
       end

--- a/lib/filewatch/tail_mode/handlers/grow.rb
+++ b/lib/filewatch/tail_mode/handlers/grow.rb
@@ -8,7 +8,7 @@ module FileWatch module TailMode module Handlers
         break if quit?
         loop_control = watched_file.loop_control_adjusted_for_stat_size
         controlled_read(watched_file, loop_control)
-        break unless loop_control.more
+        break unless loop_control.keep_looping?
       end
     end
   end

--- a/lib/filewatch/tail_mode/handlers/shrink.rb
+++ b/lib/filewatch/tail_mode/handlers/shrink.rb
@@ -9,7 +9,7 @@ module FileWatch module TailMode module Handlers
         break if quit?
         loop_control = watched_file.loop_control_adjusted_for_stat_size
         controlled_read(watched_file, loop_control)
-        break unless loop_control.more
+        break unless loop_control.keep_looping?
       end
     end
 

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.7'
+  s.version         = '4.1.8'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The processing is lagging behind, i.e. bytes read is less that file size.

1. The grow handler begins to a read of the remaining bytes from an offset - as a loop B inside loop A.
2. While the code is in loop B, the file is truncated and sysread raises an EOF error that breaks out of loop B but the watched_file thinks it still has more to read (the truncation has not been detected at this time), loop A retries loop B again without success.

Fixes #205

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
