### PR TITLE
Reduce log level of 'OPEN_WARN_INTERVAL' log message

### DIFF
--- a/lib/filewatch/read_mode/handlers/base.rb
+++ b/lib/filewatch/read_mode/handlers/base.rb
@@ -41,7 +41,7 @@ module FileWatch module ReadMode module Handlers
         # don't emit this message too often. if a file that we can't
         # read is changing a lot, we'll try to open it more often, and spam the logs.
         now = Time.now.to_i
-        logger.warn("opening OPEN_WARN_INTERVAL is '#{OPEN_WARN_INTERVAL}'")
+        logger.trace("opening OPEN_WARN_INTERVAL is '#{OPEN_WARN_INTERVAL}'")
         if watched_file.last_open_warning_at.nil? || now - watched_file.last_open_warning_at > OPEN_WARN_INTERVAL
           logger.warn("failed to open #{watched_file.path}: #{$!.inspect}, #{$!.backtrace.take(3)}")
           watched_file.last_open_warning_at = now

--- a/lib/filewatch/tail_mode/handlers/base.rb
+++ b/lib/filewatch/tail_mode/handlers/base.rb
@@ -85,7 +85,7 @@ module FileWatch module TailMode module Handlers
         # don't emit this message too often. if a file that we can't
         # read is changing a lot, we'll try to open it more often, and spam the logs.
         now = Time.now.to_i
-        logger.warn("open_file OPEN_WARN_INTERVAL is '#{OPEN_WARN_INTERVAL}'")
+        logger.trace("open_file OPEN_WARN_INTERVAL is '#{OPEN_WARN_INTERVAL}'")
         if watched_file.last_open_warning_at.nil? || now - watched_file.last_open_warning_at > OPEN_WARN_INTERVAL
           logger.warn("failed to open #{watched_file.path}: #{$!.inspect}, #{$!.backtrace.take(3)}")
           watched_file.last_open_warning_at = now


### PR DESCRIPTION
This was causing frequent log messages, negating the
logic below to reduce the frequency of log messages.
