### PR TITLE
[Build] Update dockerfile to use compatible version of Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ matrix:
   fast_finish: true
 install: ci/unit/docker-setup.sh
 script: ci/unit/docker-run.sh
-before_install: gem install bundler -v '< 2'

--- a/ci/unit/Dockerfile
+++ b/ci/unit/Dockerfile
@@ -6,6 +6,6 @@ COPY --chown=logstash:logstash . /usr/share/plugins/this
 WORKDIR /usr/share/plugins/this
 ENV PATH=/usr/share/logstash/vendor/jruby/bin:${PATH}
 ENV LOGSTASH_SOURCE 1
-RUN jruby -S gem install bundler
+RUN jruby -S gem install bundler -v '< 2'
 RUN jruby -S bundle install --jobs=3 --retry=3
 RUN jruby -S bundle exec rake vendor


### PR DESCRIPTION
Bundler 2.0 introduced requirements that are incompatible with the version of Ruby shipped with Logstash 5.6. This commit installs a pre 2.0 version of Bundler. It also removes an irrelevant step from the travis yml
