### PR TITLE
three bugs fixed

### DIFF
--- a/lib/filewatch/sincedb_collection.rb
+++ b/lib/filewatch/sincedb_collection.rb
@@ -191,7 +191,14 @@ module FileWatch
 
     def handle_association(sincedb_value, watched_file)
       watched_file.update_bytes_read(sincedb_value.position)
-      sincedb_value.set_watched_file(watched_file)
+      if watched_file.all_read?
+        # avoid the last_changed_at of sincedb_value which record the watched file has bean read over being changed when reload sincedb
+        sincedb_value.set_watched_file_without_touch(watched_file)
+        logger.trace("handle_association call set_watched_file_without_touch")
+      else
+        sincedb_value.set_watched_file(watched_file)
+        logger.trace("handle_association call set_watched_file")
+      end
       watched_file.initial_completed
       if watched_file.all_read?
         watched_file.ignore

--- a/lib/filewatch/sincedb_value.rb
+++ b/lib/filewatch/sincedb_value.rb
@@ -47,6 +47,10 @@ module FileWatch
       @watched_file = watched_file
     end
 
+    def set_watched_file_without_touch(watched_file)
+      @watched_file = watched_file
+    end
+
     def touch
       @last_changed_at = Time.now.to_f
     end

--- a/lib/filewatch/tail_mode/processor.rb
+++ b/lib/filewatch/tail_mode/processor.rb
@@ -195,6 +195,9 @@ module FileWatch module TailMode
             potential_sdb_value.set_watched_file(watched_file)
           end
         end
+        # Clean the path_in_sincedb because a file with the same name appears, this file must have been renamed
+        # Fix the duplicating collection after reloading sincedb(logstash restart or change logstash.conf)
+        sdb_value.add_path_in_sincedb(nil) unless sdb_value.nil?
         logger.trace("---------- >>>> Rotation In Progress: after handling rotation", "this watched_file details" => watched_file.details, "sincedb_value" => (potential_sdb_value || sdb_value))
       end
     end

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -105,6 +105,12 @@ module FileWatch
       if rotation_detected?
         # switch to new state now
         rotation_in_progress
+        # update the original file's size, there may be new data written after last read
+        unless @file.nil?
+          original_stat = @file.stat
+          @size = original_stat.size
+          update_bytes_unread
+        end
       else
         @size = @stat.size
         update_bytes_unread

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -106,7 +106,7 @@ module FileWatch
         # switch to new state now
         rotation_in_progress
         # update the original file's size, there may be new data written after last read
-        unless @file.nil?
+        if file_open?
           original_stat = @file.stat
           @size = original_stat.size
           update_bytes_unread


### PR DESCRIPTION
1, [The file while be processed again after logstash restart](https://github.com/logstash-plugins/logstash-input-file/issues/238)
2, all the last active timestamp in sincedb is changed after logstash restart or reload the config, it makes impact on sincedb record cleaning.
3, When the log rotates(be renamed), the contents written since the last check(stat) are lost. Because the record of file size is stale.