### PR TITLE
Ability to terminate pipeline when EOF reached 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.16
+  - Added configuration setting exit_after_read to read to EOF and terminate
+  the input [#240](https://github.com/logstash-plugins/logstash-input-file/pull/240)
+
 ## 4.1.15
   - Fixed bug in conversion of sincedb_clean_after setting [#257](https://github.com/logstash-plugins/logstash-input-file/pull/257)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -168,6 +168,7 @@ see <<plugins-{type}s-{plugin}-string_duration,string_duration>> for the details
 | <<plugins-{type}s-{plugin}-delimiter>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-discover_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-exclude>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-exit_after_read>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-file_chunk_count>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-file_chunk_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-file_completed_action>> |<<string,string>>, one of `["delete", "log", "log_and_delete"]`|No
@@ -240,6 +241,19 @@ patterns are valid here, too. For example, if you have
 In Tail mode, you might want to exclude gzipped files:
 [source,ruby]
     exclude => "*.gz"
+
+[id="plugins-{type}s-{plugin}-exit_after_read"]
+===== `exit_after_read`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+This option can be used in `read` mode to enforce closing all watchers when file gets read.
+Can be used in situation when content of the file is static and won't change during execution.
+When set to `true` it also disables active discovery of the files - only files that were in 
+the directories when process was started will be read.
+It supports `sincedb` entries. When file was processed once, then modified - next run will only
+read newly added entries.
 
 [id="plugins-{type}s-{plugin}-file_chunk_count"]
 ===== `file_chunk_count`

--- a/lib/filewatch/read_mode/processor.rb
+++ b/lib/filewatch/read_mode/processor.rb
@@ -103,8 +103,19 @@ module FileWatch module ReadMode
         else
           read_file(watched_file)
         end
+        
+        if @settings.exit_after_read
+          common_detach_when_allread(watched_file)
+        end
         # handlers take care of closing and unwatching
       end
+    end
+
+    def common_detach_when_allread(watched_file)
+      watched_file.unwatch
+      watched_file.listener.reading_completed
+      deletable_filepaths << watched_file.path
+      logger.trace("Whole file read: #{watched_file.path}, removing from collection")
     end
 
     def common_deleted_reaction(watched_file, action)

--- a/lib/filewatch/settings.rb
+++ b/lib/filewatch/settings.rb
@@ -8,6 +8,7 @@ module FileWatch
     attr_reader :exclude, :start_new_files_at, :file_chunk_count, :file_chunk_size
     attr_reader :sincedb_path, :sincedb_write_interval, :sincedb_expiry_duration
     attr_reader :file_sort_by, :file_sort_direction
+    attr_reader :exit_after_read
 
     def self.from_options(opts)
       new.add_options(opts)
@@ -50,6 +51,7 @@ module FileWatch
       @sincedb_expiry_duration =  @opts.fetch(:sincedb_clean_after)
       @file_sort_by = @opts[:file_sort_by]
       @file_sort_direction = @opts[:file_sort_direction]
+      @exit_after_read = @opts[:exit_after_read]
       self
     end
 

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -43,10 +43,11 @@ module FileWatch
       reset_quit
       until quit?
         iterate_on_state
+        # Don't discover new files when files to read are known at the beginning
         break if quit?
         sincedb_collection.write_if_requested
         glob += 1
-        if glob == interval
+        if glob == interval && !@settings.exit_after_read
           discover
           glob = 0
         end
@@ -76,7 +77,10 @@ module FileWatch
     end
 
     def quit?
-      @quit.true?
+      if @settings.exit_after_read
+        @exit = @watched_files_collection.empty?
+      end
+      @quit.true? || @exit
     end
 
     private

--- a/lib/logstash/inputs/file_listener.rb
+++ b/lib/logstash/inputs/file_listener.rb
@@ -21,6 +21,9 @@ module LogStash module Inputs
     def error
     end
 
+    def reading_completed
+    end
+
     def timed_out
       input.codec.evict(path)
     end

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.15'
+  s.version         = '4.1.16'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filewatch/spec_helper.rb
+++ b/spec/filewatch/spec_helper.rb
@@ -152,6 +152,10 @@ module FileWatch
       def timed_out
         @calls << :timed_out
       end
+
+      def reading_completed
+        @calls << :reading_completed
+      end
     end
 
     attr_reader :listeners

--- a/spec/filewatch/tailing_spec.rb
+++ b/spec/filewatch/tailing_spec.rb
@@ -448,7 +448,7 @@ module FileWatch
             FileUtils.mv(file_path2, file_path3)
           end
           .then("wait") do
-            wait(2).for do
+            wait(4).for do
               listener1.lines.size == 32 && listener2.calls == [:delete] && listener3.calls == [:open, :accept, :timed_out]
             end.to eq(true), "listener1.lines != 32 or listener2.calls != [:delete] or listener3.calls != [:open, :accept, :timed_out]"
           end

--- a/spec/inputs/file_tail_spec.rb
+++ b/spec/inputs/file_tail_spec.rb
@@ -175,7 +175,7 @@ describe LogStash::Inputs::File do
     context "when sincedb_path is a directory" do
       let(:name) { "E" }
       subject { LogStash::Inputs::File.new("path" => path_path, "sincedb_path" => directory) }
-
+      
       after :each do
         FileUtils.rm_rf(sincedb_path)
       end
@@ -184,6 +184,15 @@ describe LogStash::Inputs::File do
         expect { subject.register }.to raise_error(ArgumentError)
       end
     end
+
+    context "when mode it set to tail and exit_after_read equals true" do
+        subject { LogStash::Inputs::File.new("path" => path_path, "exit_after_read" => true, "mode" => "tail") }
+
+      it "should raise exception" do
+        expect { subject.register }.to raise_error(ArgumentError)
+      end
+    end
+
   end
 
   describe "testing with new, register, run and stop" do


### PR DESCRIPTION
Adding ability to terminate pipeline when EOF reached (#212)
Change is backwards compatible. When flag is set to 'false' - no change to code execution.

Changes:
        * Adding exit_after_read flag to config
        * Disable active discovery when exit_after_read set to true
        * Remove file from watched_file_collection when EOF reached and flag set to true
        * Adding condition to exit when file collection is empty and flag set to true
        * Fixing WatchedFilesCollection delete method bug (unable to delete multiple files with 1 method call)
        * Adding exception when exit_after_read it set to true in tail mode

Fixes #212