### PR TITLE
Fix #248, sinceDB now can handle pathnames with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.13
+  - Fixed sinceDB to work spaces filename [#249](https://github.com/logstash-plugins/logstash-input-file/pull/249)
+
 ## 4.1.12
   - Fix regression in `exclude` handling. Patterns are matched against the filename, not full path.
     [Issue #237](https://github.com/logstash-plugins/logstash-input-file/issues/237)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ bundle install
 bundle install
 ```
 
+ - Build the jar library used for watching files
+```bash
+./gradlew build
+```
+
 - Run tests
 
 ```sh

--- a/lib/filewatch/sincedb_record_serializer.rb
+++ b/lib/filewatch/sincedb_record_serializer.rb
@@ -51,7 +51,7 @@ module FileWatch
       inode_struct = prepare_inode_struct(parts)
       pos = parts.shift.to_i
       expires_at = Float(parts.shift) # this is like Time.now.to_f
-      path_in_sincedb = parts.shift
+      path_in_sincedb = parts.join(" ")
       value = SincedbValue.new(pos, expires_at).add_path_in_sincedb(path_in_sincedb)
       [inode_struct, value]
     end

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.12'
+  s.version         = '4.1.13'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #248

This also fixes a couple of tests that previously didn't test anything
due to the input IO iterator not being rewound before being passed
to the code under test.

Also, this updates the README to specify a missing build step.