### PR TITLE
discoverer.rb: Exclude patterns match filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.12
+  - Fix regression in `exclude` handling. Patterns are matched against the filename, not full path.
+    [Issue #237](https://github.com/logstash-plugins/logstash-input-file/issues/237)
+
 ## 4.1.11
   - Fixed link to FAQ [#247](https://github.com/logstash-plugins/logstash-input-file/pull/247)
 

--- a/lib/filewatch/discoverer.rb
+++ b/lib/filewatch/discoverer.rb
@@ -35,7 +35,7 @@ module FileWatch
 
     def can_exclude?(watched_file, new_discovery)
       @exclude.each do |pattern|
-        if watched_file.pathname.fnmatch?(pattern)
+        if watched_file.pathname.basename.fnmatch?(pattern)
           if new_discovery
             logger.trace("Discoverer can_exclude?: #{watched_file.path}: skipping " +
               "because it matches exclude #{pattern}")

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.11'
+  s.version         = '4.1.12'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
https://github.com/logstash-plugins/logstash-input-file/issues/237

[The documentation says:](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-file.html#plugins-inputs-file-exclude) _Exclusions (matched against the filename, not full path). Filename patterns are valid here, too._ 

Fix `can_exclude?` method so it matches the filename and not the full pathname.