### PR TITLE
Increased wait period to let the watcher to process previous contents

### DIFF
--- a/spec/filewatch/tailing_spec.rb
+++ b/spec/filewatch/tailing_spec.rb
@@ -90,7 +90,7 @@ module FileWatch
       end
     end
 
-    context "when watching a directory with files, exisiting content is skipped" do
+    context "when watching a directory with files, existing content is skipped" do
       let(:suffix) { "C" }
       let(:actions) do
         RSpec::Sequencing
@@ -100,11 +100,11 @@ module FileWatch
           .then_after(0.1, "begin watching") do
             tailing.watch_this(watch_dir)
           end
-          .then_after(0.2, "add content") do
+          .then_after(2, "add content") do
             File.open(file_path, "ab") { |file|  file.write("line1\nline2\n") }
           end
           .then("wait") do
-            wait(0.75).for{listener1.lines.size}.to eq(2)
+            wait(0.75).for{listener1.lines}.to eq(["line1", "line2"])
           end
           .then("quit") do
             tailing.quit


### PR DESCRIPTION
Try to fix a flaky failing test. 
The test write 2 lines on a file, then give time to file watcher to consume it, then writes another 2 lines and check that the last 2 lines are correctly picked up.
Increased the time for the first processing and made more explicit what the expect asks.