### PR TITLE
Fixing delete method to work with multiple files

### DIFF
--- a/lib/filewatch/watched_files_collection.rb
+++ b/lib/filewatch/watched_files_collection.rb
@@ -19,6 +19,7 @@ module FileWatch
       Array(paths).each do |f|
         index = @pointers.delete(f)
         @files.delete_at(index)
+        refresh_pointers
       end
       @sort_method.call
     end

--- a/spec/filewatch/watched_files_collection_spec.rb
+++ b/spec/filewatch/watched_files_collection_spec.rb
@@ -4,12 +4,15 @@ require_relative 'spec_helper'
 module FileWatch
   describe WatchedFilesCollection do
     let(:time) { Time.now }
+    let(:filepath1){"/var/log/z.log"}
+    let(:filepath2){"/var/log/m.log"}
+    let(:filepath3){"/var/log/a.log"}
     let(:stat1)  { double("stat1", :size => 98, :modified_at => time - 30, :identifier => nil, :inode => 234567, :inode_struct => InodeStruct.new("234567", 3, 2)) }
     let(:stat2)  { double("stat2", :size => 99, :modified_at => time - 20, :identifier => nil, :inode => 234568, :inode_struct => InodeStruct.new("234568", 3, 2)) }
     let(:stat3)  { double("stat3", :size => 100, :modified_at => time, :identifier => nil, :inode => 234569, :inode_struct => InodeStruct.new("234569", 3, 2)) }
-    let(:wf1) { WatchedFile.new("/var/log/z.log", stat1, Settings.new) }
-    let(:wf2) { WatchedFile.new("/var/log/m.log", stat2, Settings.new) }
-    let(:wf3) { WatchedFile.new("/var/log/a.log", stat3, Settings.new) }
+    let(:wf1) { WatchedFile.new(filepath1, stat1, Settings.new) }
+    let(:wf2) { WatchedFile.new(filepath2, stat2, Settings.new) }
+    let(:wf3) { WatchedFile.new(filepath3, stat3, Settings.new) }
 
     context "sort by last_modified in ascending order" do
       let(:sort_by) { "last_modified" }
@@ -70,5 +73,23 @@ module FileWatch
         expect(collection.values).to eq([wf1, wf2, wf3])
       end
     end
+
+    context "when delete called" do
+      let(:sort_by) { "path" }
+      let(:sort_direction) { "desc" }
+
+      it "is able to delete multiple files at once" do
+        collection = described_class.new(Settings.from_options(:file_sort_by => sort_by, :file_sort_direction => sort_direction))
+        collection.add(wf1)
+        collection.add(wf2)
+        collection.add(wf3)
+        expect(collection.keys).to eq([filepath1, filepath2, filepath3])
+
+        collection.delete([filepath2,filepath3])
+        expect(collection.keys).to eq([filepath1])
+
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fixing bug in `WatchedFilesCollection`.
`Delete` method wasn't working when multiple file paths were provided to delete.
This fix was pulled from #240 as requested by @andsel 