### PR TITLE
Bugfixed double conversion to seconds of sincedb_clean_after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.15
+  - Fixed bug in conversion of sincedb_clean_after setting [#257](https://github.com/logstash-plugins/logstash-input-file/pull/257)
+
 ## 4.1.14
   - Fixed bug in delete of multiple watched files [#254](https://github.com/logstash-plugins/logstash-input-file/pull/254)
 

--- a/lib/filewatch/settings.rb
+++ b/lib/filewatch/settings.rb
@@ -13,10 +13,6 @@ module FileWatch
       new.add_options(opts)
     end
 
-    def self.days_to_seconds(days)
-      (24 * 3600) * days.to_f
-    end
-
     def initialize
       defaults = {
         :delimiter => "\n",
@@ -51,7 +47,7 @@ module FileWatch
       @file_chunk_count = @opts[:file_chunk_count]
       @sincedb_path = @opts[:sincedb_path]
       @sincedb_write_interval = @opts[:sincedb_write_interval]
-      @sincedb_expiry_duration =  self.class.days_to_seconds(@opts.fetch(:sincedb_clean_after, 14))
+      @sincedb_expiry_duration =  @opts.fetch(:sincedb_clean_after)
       @file_sort_by = @opts[:file_sort_by]
       @file_sort_direction = @opts[:file_sort_direction]
       self

--- a/lib/filewatch/sincedb_record_serializer.rb
+++ b/lib/filewatch/sincedb_record_serializer.rb
@@ -5,13 +5,17 @@ module FileWatch
 
     attr_reader :expired_keys
 
+    def self.days_to_seconds(days)
+      (24 * 3600) * days.to_f
+    end
+
     def initialize(sincedb_value_expiry)
       @sincedb_value_expiry = sincedb_value_expiry
       @expired_keys = []
     end
 
     def update_sincedb_value_expiry_from_days(days)
-      @sincedb_value_expiry = Settings.days_to_seconds(days)
+      @sincedb_value_expiry = SincedbRecordSerializer.days_to_seconds(days)
     end
 
     def serialize(db, io, as_of = Time.now.to_f)

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.14'
+  s.version         = '4.1.15'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filewatch/settings_spec.rb
+++ b/spec/filewatch/settings_spec.rb
@@ -1,0 +1,11 @@
+describe FileWatch::Settings do
+
+  context "when create from options" do
+    it "doesn't convert sincedb_clean_after to seconds" do
+      res = FileWatch::Settings.from_options({:sincedb_clean_after => LogStash::Inputs::FriendlyDurations.call(1, "days").value})
+
+      expect(res.sincedb_expiry_duration).to eq 1 * 24 * 3600
+    end
+  end
+
+end

--- a/spec/filewatch/sincedb_record_serializer_spec.rb
+++ b/spec/filewatch/sincedb_record_serializer_spec.rb
@@ -9,7 +9,7 @@ module FileWatch
     let(:io) { StringIO.new }
     let(:db) { Hash.new }
 
-    subject { SincedbRecordSerializer.new(Settings.days_to_seconds(14)) }
+    subject { SincedbRecordSerializer.new(SincedbRecordSerializer.days_to_seconds(14)) }
 
     context "deserialize from IO" do
       it 'reads V1 records' do


### PR DESCRIPTION
Related to issue #231 where the value of setting `sincedb_clean_after` results to be multiplied by 24 * 3600 twice, so that 14 hours become 104509440000 second. It's due to the fact that after commit 28c0534e0d61ed724d867e68c55ad19aa9835b45 the old conversion method wasn't removed
