### PR TITLE
Fix: watched files performance with huge filesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.0
+  - Fix: watched files performance with huge filesets [#268](https://github.com/logstash-plugins/logstash-input-file/pull/268) 
+  - Updated logging to include full traces in debug (and trace) levels
+
 ## 4.1.18
   - Fix: release watched files on completion (in read-mode) [#271](https://github.com/logstash-plugins/logstash-input-file/pull/271)
 

--- a/lib/filewatch/discoverer.rb
+++ b/lib/filewatch/discoverer.rb
@@ -9,6 +9,8 @@ module FileWatch
     # associated with a sincedb entry if one can be found
     include LogStash::Util::Loggable
 
+    attr_reader :watched_files_collection
+
     def initialize(watched_files_collection, sincedb_collection, settings)
       @watching = Concurrent::Array.new
       @exclude = Concurrent::Array.new

--- a/lib/filewatch/discoverer.rb
+++ b/lib/filewatch/discoverer.rb
@@ -61,7 +61,7 @@ module FileWatch
       fileset.each do |file|
         pathname = Pathname.new(file)
         new_discovery = false
-        watched_file = @watched_files_collection.watched_file_by_path(file)
+        watched_file = @watched_files_collection.get(file)
         if watched_file.nil?
           begin
             path_stat = PathStatClass.new(pathname)

--- a/lib/filewatch/observing_base.rb
+++ b/lib/filewatch/observing_base.rb
@@ -62,8 +62,7 @@ module FileWatch
       @sincedb_collection = SincedbCollection.new(@settings)
       @sincedb_collection.open
       discoverer = Discoverer.new(watched_files_collection, @sincedb_collection, @settings)
-      @watch = Watch.new(discoverer, watched_files_collection, @settings)
-      @watch.add_processor build_specific_processor(@settings)
+      @watch = Watch.new(discoverer, build_specific_processor(@settings), @settings)
     end
 
     def watch_this(path)

--- a/lib/filewatch/processor.rb
+++ b/lib/filewatch/processor.rb
@@ -26,6 +26,16 @@ module FileWatch
       @deletable_paths.get << path
     end
 
+    def restat(watched_file)
+      changed = watched_file.restat!
+      if changed
+        # the collection (when sorted by modified_at) needs to re-sort every time watched-file is modified,
+        # we can perform these update operation while processing files (stat interval) instead of having to
+        # re-sort the whole collection every time an entry is accessed
+        @watch.watched_files_collection.update(watched_file)
+      end
+    end
+
     private
 
     def error_details(error, watched_file)

--- a/lib/filewatch/processor.rb
+++ b/lib/filewatch/processor.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+require "logstash/util/loggable"
+require 'concurrent/atomic/atomic_reference'
+
+module FileWatch
+  class Processor
+    include LogStash::Util::Loggable
+
+    attr_reader :watch
+
+    def initialize(settings)
+      @settings = settings
+      @deletable_paths = Concurrent::AtomicReference.new []
+    end
+
+    def add_watch(watch)
+      @watch = watch
+      self
+    end
+
+    def clear_deletable_paths
+      @deletable_paths.get_and_set []
+    end
+
+    def add_deletable_path(path)
+      @deletable_paths.get << path
+    end
+
+    private
+
+    def error_details(error, watched_file)
+      details = { :path => watched_file.path,
+                  :exception => error.class,
+                  :message => error.message,
+                  :backtrace => error.backtrace }
+      if logger.debug?
+        details[:file] = watched_file
+      else
+        details[:backtrace] = details[:backtrace].take(8) if details[:backtrace]
+      end
+      details
+    end
+
+  end
+end

--- a/lib/filewatch/read_mode/handlers/read_zip_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_zip_file.rb
@@ -1,13 +1,15 @@
 # encoding: utf-8
 require 'java'
-java_import java.io.InputStream
-java_import java.io.InputStreamReader
-java_import java.io.FileInputStream
-java_import java.io.BufferedReader
-java_import java.util.zip.GZIPInputStream
-java_import java.util.zip.ZipException
 
 module FileWatch module ReadMode module Handlers
+
+  java_import java.io.InputStream
+  java_import java.io.InputStreamReader
+  java_import java.io.FileInputStream
+  java_import java.io.BufferedReader
+  java_import java.util.zip.GZIPInputStream
+  java_import java.util.zip.ZipException
+
   class ReadZipFile < Base
     def handle_specifically(watched_file)
       add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)

--- a/lib/filewatch/read_mode/processor.rb
+++ b/lib/filewatch/read_mode/processor.rb
@@ -44,7 +44,7 @@ module FileWatch module ReadMode
       if to_take > 0
         watched_files.select(&:watched?).take(to_take).each do |watched_file|
           begin
-            watched_file.restat
+            restat(watched_file)
             watched_file.activate
           rescue Errno::ENOENT
             common_deleted_reaction(watched_file, __method__)
@@ -74,7 +74,7 @@ module FileWatch module ReadMode
         next unless watched_file.active?
 
         begin
-          watched_file.restat
+          restat(watched_file)
         rescue Errno::ENOENT
           common_deleted_reaction(watched_file, __method__)
           next

--- a/lib/filewatch/read_mode/processor.rb
+++ b/lib/filewatch/read_mode/processor.rb
@@ -60,9 +60,9 @@ module FileWatch module ReadMode
       #   move to the active state
       #   should never have been active before
       # how much of the max active window is available
-      to_take = @settings.max_active - watched_files.count{|wf| wf.active?}
+      to_take = @settings.max_active - watched_files.count { |wf| wf.active? }
       if to_take > 0
-        watched_files.select {|wf| wf.watched?}.take(to_take).each do |watched_file|
+        watched_files.select(&:watched?).take(to_take).each do |watched_file|
           path = watched_file.path
           begin
             watched_file.restat
@@ -91,7 +91,9 @@ module FileWatch module ReadMode
     def process_active(watched_files)
       logger.trace("Active processing")
       # Handles watched_files in the active state.
-      watched_files.select {|wf| wf.active? }.each do |watched_file|
+      watched_files.each do |watched_file|
+        next unless watched_file.active?
+
         path = watched_file.path
         begin
           watched_file.restat

--- a/lib/filewatch/read_mode/processor.rb
+++ b/lib/filewatch/read_mode/processor.rb
@@ -12,7 +12,7 @@ module FileWatch module ReadMode
   class Processor
     include LogStash::Util::Loggable
 
-    attr_reader :watch, :deletable_filepaths
+    attr_reader :watch
 
     def initialize(settings)
       @settings = settings
@@ -43,6 +43,12 @@ module FileWatch module ReadMode
       process_watched(watched_files)
       return if watch.quit?
       process_active(watched_files)
+    end
+
+    def deletable_filepaths(clear: false)
+      deletable_filepaths = @deletable_filepaths
+      @deletable_filepaths = [] if clear
+      deletable_filepaths
     end
 
     private

--- a/lib/filewatch/read_mode/processor.rb
+++ b/lib/filewatch/read_mode/processor.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
-require "logstash/util/loggable"
-
+require 'filewatch/processor'
 require_relative "handlers/base"
 require_relative "handlers/read_file"
 require_relative "handlers/read_zip_file"
@@ -9,20 +8,7 @@ module FileWatch module ReadMode
   # Must handle
   #   :read_file
   #   :read_zip_file
-  class Processor
-    include LogStash::Util::Loggable
-
-    attr_reader :watch
-
-    def initialize(settings)
-      @settings = settings
-      @deletable_filepaths = []
-    end
-
-    def add_watch(watch)
-      @watch = watch
-      self
-    end
+  class Processor < FileWatch::Processor
 
     def initialize_handlers(sincedb_collection, observer)
       # we deviate from the tail mode handler initialization here
@@ -45,16 +31,10 @@ module FileWatch module ReadMode
       process_active(watched_files)
     end
 
-    def deletable_filepaths(clear: false)
-      deletable_filepaths = @deletable_filepaths
-      @deletable_filepaths = [] if clear
-      deletable_filepaths
-    end
-
     private
 
     def process_watched(watched_files)
-      logger.trace("Watched processing")
+      logger.trace(__method__.to_s)
       # Handles watched_files in the watched state.
       # for a slice of them:
       #   move to the active state
@@ -63,15 +43,14 @@ module FileWatch module ReadMode
       to_take = @settings.max_active - watched_files.count { |wf| wf.active? }
       if to_take > 0
         watched_files.select(&:watched?).take(to_take).each do |watched_file|
-          path = watched_file.path
           begin
             watched_file.restat
             watched_file.activate
           rescue Errno::ENOENT
-            common_deleted_reaction(watched_file, "Watched")
+            common_deleted_reaction(watched_file, __method__)
             next
           rescue => e
-            common_error_reaction(path, e, "Watched")
+            common_error_reaction(watched_file, e, __method__)
             next
           end
           break if watch.quit?
@@ -80,7 +59,7 @@ module FileWatch module ReadMode
         now = Time.now.to_i
         if (now - watch.lastwarn_max_files) > MAX_FILES_WARN_INTERVAL
           waiting = watched_files.size - @settings.max_active
-          logger.warn(@settings.max_warn_msg + ", files yet to open: #{waiting}")
+          logger.warn("#{@settings.max_warn_msg}, files yet to open: #{waiting}")
           watch.lastwarn_max_files = now
         end
       end
@@ -89,19 +68,18 @@ module FileWatch module ReadMode
     ## TODO add process_rotation_in_progress
 
     def process_active(watched_files)
-      logger.trace("Active processing")
+      logger.trace(__method__.to_s)
       # Handles watched_files in the active state.
       watched_files.each do |watched_file|
         next unless watched_file.active?
 
-        path = watched_file.path
         begin
           watched_file.restat
         rescue Errno::ENOENT
-          common_deleted_reaction(watched_file, "Active")
+          common_deleted_reaction(watched_file, __method__)
           next
         rescue => e
-          common_error_reaction(path, e, "Active")
+          common_error_reaction(watched_file, e, __method__)
           next
         end
         break if watch.quit?
@@ -122,19 +100,19 @@ module FileWatch module ReadMode
     def common_detach_when_allread(watched_file)
       watched_file.unwatch
       watched_file.listener.reading_completed
-      deletable_filepaths << watched_file.path
-      logger.trace("Whole file read: #{watched_file.path}, removing from collection")
+      add_deletable_path watched_file.path
+      logger.trace? && logger.trace("whole file read, removing from collection", :path => watched_file.path)
     end
 
     def common_deleted_reaction(watched_file, action)
       # file has gone away or we can't read it anymore.
       watched_file.unwatch
-      deletable_filepaths << watched_file.path
-      logger.trace("#{action} - stat failed: #{watched_file.path}, removing from collection")
+      add_deletable_path watched_file.path
+      logger.trace? && logger.trace("#{action} - stat failed, removing from collection", :path => watched_file.path)
     end
 
-    def common_error_reaction(path, error, action)
-      logger.error("#{action} - other error #{path}: (#{error.message}, #{error.backtrace.take(8).inspect})")
+    def common_error_reaction(watched_file, error, action)
+      logger.error("#{action} - other error", error_details(error, watched_file))
     end
   end
 end end

--- a/lib/filewatch/sincedb_collection.rb
+++ b/lib/filewatch/sincedb_collection.rb
@@ -149,8 +149,8 @@ module FileWatch
     end
 
     def watched_file_deleted(watched_file)
-      return unless member?(watched_file.sincedb_key)
-      get(watched_file.sincedb_key).unset_watched_file
+      value = @sincedb[watched_file.sincedb_key]
+      value.unset_watched_file if value
     end
 
     def store_last_read(key, pos)

--- a/lib/filewatch/sincedb_collection.rb
+++ b/lib/filewatch/sincedb_collection.rb
@@ -71,7 +71,8 @@ module FileWatch
         logger.trace("associate: unmatched")
         return true
       end
-      logger.trace("associate: found sincedb record", "filename" => watched_file.filename, "sincedb key" => watched_file.sincedb_key,"sincedb_value" => sincedb_value)
+      logger.trace? && logger.trace("associate: found sincedb record", :filename => watched_file.filename,
+                                    :sincedb_key => watched_file.sincedb_key, :sincedb_value => sincedb_value)
       if sincedb_value.watched_file.nil?
         # not associated
         if sincedb_value.path_in_sincedb.nil?
@@ -106,7 +107,8 @@ module FileWatch
       #   after the original is deleted
       # are not yet in the delete phase, let this play out
       existing_watched_file = sincedb_value.watched_file
-      logger.trace("----------------- >> associate: the found sincedb_value has a watched_file - this is a rename", "this watched_file details" => watched_file.details, "other watched_file details" => existing_watched_file.details)
+      logger.trace? && logger.trace("----------------- >> associate: the found sincedb_value has a watched_file - this is a rename",
+                                    :this_watched_file => watched_file.details, :existing_watched_file => existing_watched_file.details)
       watched_file.rotation_in_progress
       true
     end
@@ -195,7 +197,7 @@ module FileWatch
       watched_file.initial_completed
       if watched_file.all_read?
         watched_file.ignore
-        logger.trace("handle_association fully read, ignoring.....", "watched file" => watched_file.details, "sincedb value" => sincedb_value)
+        logger.trace? && logger.trace("handle_association fully read, ignoring.....", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
       end
     end
 
@@ -214,8 +216,8 @@ module FileWatch
         @write_method.call
         @serializer.expired_keys.each do |key|
           @sincedb[key].unset_watched_file
-          delete(key)
-          logger.trace("sincedb_write: cleaned", "key" => "'#{key}'")
+          delete(key) # delete
+          logger.trace? && logger.trace("sincedb_write: cleaned", :key => key)
         end
         @sincedb_last_write = time
         @write_requested = false

--- a/lib/filewatch/sincedb_collection.rb
+++ b/lib/filewatch/sincedb_collection.rb
@@ -56,12 +56,12 @@ module FileWatch
         logger.trace("open: count of keys read: #{@sincedb.keys.size}")
       rescue => e
         #No existing sincedb to load
-        logger.trace("open: error: #{path}: #{e.inspect}")
+        logger.trace("open: error:", :path => path, :exception => e.class, :message => e.message)
       end
     end
 
     def associate(watched_file)
-      logger.trace("associate: finding", "inode" => watched_file.sincedb_key.inode, "path" => watched_file.path)
+      logger.trace? && logger.trace("associate: finding", :path => watched_file.path, :inode => watched_file.sincedb_key.inode)
       sincedb_value = find(watched_file)
       if sincedb_value.nil?
         # sincedb has no record of this inode

--- a/lib/filewatch/stat/generic.rb
+++ b/lib/filewatch/stat/generic.rb
@@ -3,24 +3,19 @@
 module FileWatch module Stat
   class Generic
 
-    attr_reader :identifier, :inode, :modified_at, :size, :inode_struct
+    attr_reader :inode, :modified_at, :size, :inode_struct
 
     def initialize(source)
-      @source = source
-      @identifier = nil
+      @source = source # Pathname
       restat
     end
 
-    def add_identifier(identifier) self; end
-
     def restat
-      @inner_stat = @source.stat
-      @inode = @inner_stat.ino.to_s
-      @modified_at = @inner_stat.mtime.to_f
-      @size = @inner_stat.size
-      @dev_major = @inner_stat.dev_major
-      @dev_minor = @inner_stat.dev_minor
-      @inode_struct = InodeStruct.new(@inode, @dev_major, @dev_minor)
+      stat = @source.stat
+      @inode = stat.ino.to_s
+      @modified_at = stat.mtime.to_f
+      @size = stat.size
+      @inode_struct = InodeStruct.new(@inode, stat.dev_major, stat.dev_minor)
     end
 
     def windows?
@@ -28,7 +23,7 @@ module FileWatch module Stat
     end
 
     def inspect
-      "<Generic size='#{@size}', modified_at='#{@modified_at}', inode='#{@inode}', inode_struct='#{@inode_struct}'>"
+      "<#{self.class.name} size=#{@size}, modified_at=#{@modified_at}, inode='#{@inode}', inode_struct=#{@inode_struct}>"
     end
   end
 end end

--- a/lib/filewatch/stat/windows_path.rb
+++ b/lib/filewatch/stat/windows_path.rb
@@ -3,22 +3,20 @@
 module FileWatch module Stat
   class WindowsPath
 
-    attr_reader :identifier, :inode, :modified_at, :size, :inode_struct
+    attr_reader :inode, :modified_at, :size, :inode_struct
 
     def initialize(source)
-      @source = source
+      @source = source # Pathname
       @inode = Winhelper.identifier_from_path(@source.to_path)
-      @dev_major = 0
-      @dev_minor = 0
       # in windows the dev hi and low are in the identifier
-      @inode_struct = InodeStruct.new(@inode, @dev_major, @dev_minor)
+      @inode_struct = InodeStruct.new(@inode, 0, 0)
       restat
     end
 
     def restat
-      @inner_stat = @source.stat
-      @modified_at = @inner_stat.mtime.to_f
-      @size = @inner_stat.size
+      stat = @source.stat
+      @modified_at = stat.mtime.to_f
+      @size = stat.size
     end
 
     def windows?
@@ -26,7 +24,7 @@ module FileWatch module Stat
     end
 
     def inspect
-      "<WindowsPath size='#{@size}', modified_at='#{@modified_at}', inode='#{@inode}', inode_struct='#{@inode_struct}'>"
+      "<#{self.class.name} size=#{@size}, modified_at=#{@modified_at}, inode=#{@inode}, inode_struct=#{@inode_struct}>"
     end
   end
 end end

--- a/lib/filewatch/tail_mode/handlers/delete.rb
+++ b/lib/filewatch/tail_mode/handlers/delete.rb
@@ -7,11 +7,9 @@ module FileWatch module TailMode module Handlers
       # TODO consider trying to find the renamed file - it will have the same inode.
       # Needs a rotate scheme rename hint from user e.g. "<name>-YYYY-MM-DD-N.<ext>" or "<name>.<ext>.N"
       # send the found content to the same listener (stream identity)
-      logger.trace("info",
-        "watched_file details" => watched_file.details,
-        "path" => watched_file.path)
+      logger.trace("delete", :path => watched_file.path, :watched_file => watched_file.details)
       if watched_file.bytes_unread > 0
-        logger.warn(DATA_LOSS_WARNING, "unread_bytes" => watched_file.bytes_unread, "path" => watched_file.path)
+        logger.warn(DATA_LOSS_WARNING, :path => watched_file.path, :unread_bytes => watched_file.bytes_unread)
       end
       watched_file.listener.deleted
       # no need to worry about data in the buffer

--- a/lib/filewatch/tail_mode/processor.rb
+++ b/lib/filewatch/tail_mode/processor.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require "logstash/util/loggable"
+require 'filewatch/processor'
 require_relative "handlers/base"
 require_relative "handlers/create_initial"
 require_relative "handlers/create"
@@ -18,20 +18,7 @@ module FileWatch module TailMode
   #   :delete   - file can't be read
   #   :timeout - file is closable
   #   :unignore - file was ignored, but have now received new content
-  class Processor
-    include LogStash::Util::Loggable
-
-    attr_reader :watch
-
-    def initialize(settings)
-      @settings = settings
-      @deletable_filepaths = []
-    end
-
-    def add_watch(watch)
-      @watch = watch
-      self
-    end
+  class Processor < FileWatch::Processor
 
     def initialize_handlers(sincedb_collection, observer)
       @sincedb_collection = sincedb_collection
@@ -88,21 +75,15 @@ module FileWatch module TailMode
       process_active(watched_files)
     end
 
-    def deletable_filepaths(clear: false)
-      deletable_filepaths = @deletable_filepaths
-      @deletable_filepaths = [] if clear
-      deletable_filepaths
-    end
-
     private
 
     def process_closed(watched_files)
-      # logger.trace("Closed processing")
+      logger.trace(__method__.to_s)
       # Handles watched_files in the closed state.
       # if its size changed it is put into the watched state
       watched_files.each do |watched_file|
         next unless watched_file.closed?
-        common_restat_with_delay(watched_file, "Closed") do
+        common_restat_with_delay(watched_file, __method__) do
           # it won't do this if rotation is detected
           if watched_file.size_changed?
             # if the closed file changed, move it to the watched state
@@ -115,14 +96,14 @@ module FileWatch module TailMode
     end
 
     def process_ignored(watched_files)
-      # logger.trace("Ignored processing")
+      logger.trace(__method__.to_s)
       # Handles watched_files in the ignored state.
       # if its size changed:
       #   put it in the watched state
       #   invoke unignore
       watched_files.each do |watched_file|
         next unless watched_file.ignored?
-        common_restat_with_delay(watched_file, "Ignored") do
+        common_restat_with_delay(watched_file, __method__) do
           # it won't do this if rotation is detected
           if watched_file.size_changed?
             watched_file.watch
@@ -136,12 +117,12 @@ module FileWatch module TailMode
     def process_delayed_delete(watched_files)
       # defer the delete to one loop later to ensure that the stat really really can't find a renamed file
       # because a `stat` can be called right in the middle of the rotation rename cascade
-      logger.trace("Delayed Delete processing")
+      logger.trace(__method__.to_s)
       watched_files.each do |watched_file|
         next unless watched_file.delayed_delete?
-        logger.trace(">>> Delayed Delete", "path" => watched_file.filename)
-        common_restat_without_delay(watched_file, ">>> Delayed Delete") do
-          logger.trace(">>> Delayed Delete: file at path found again", "watched_file" => watched_file.details)
+        logger.trace(">>> Delayed Delete", :path => watched_file.path)
+        common_restat_without_delay(watched_file, __method__) do
+          logger.trace(">>> Delayed Delete: file at path found again", :watched_file => watched_file.details)
           watched_file.file_at_path_found_again
         end
       end
@@ -149,35 +130,35 @@ module FileWatch module TailMode
 
     def process_restat_for_watched_and_active(watched_files)
       # do restat on all watched and active states once now. closed and ignored have been handled already
-      logger.trace("Watched + Active restat processing")
+      logger.trace(__method__.to_s)
       watched_files.each do |watched_file|
         next if !watched_file.watched? && !watched_file.active?
-        common_restat_with_delay(watched_file, "Watched")
+        common_restat_with_delay(watched_file, __method__)
       end
     end
 
     def process_rotation_in_progress(watched_files)
-      logger.trace("Rotation In Progress processing")
+      logger.trace(__method__.to_s)
       watched_files.each do |watched_file|
         next unless watched_file.rotation_in_progress?
         if !watched_file.all_read?
           if watched_file.file_open?
             # rotated file but original opened file is not fully read
             # we need to keep reading the open file, if we close it we lose it because the path is now pointing at a different file.
-            logger.trace(">>> Rotation In Progress - inode change detected and original content is not fully read, reading all", "watched_file details" => watched_file.details)
+            logger.trace(">>> Rotation In Progress - inode change detected and original content is not fully read, reading all", :watched_file => watched_file.details)
             # need to fully read open file while we can
             watched_file.set_maximum_read_loop
             grow(watched_file)
             watched_file.set_standard_read_loop
           else
-            logger.warn(">>> Rotation In Progress - inode change detected and original content is not fully read, file is closed and path points to new content", "watched_file details" => watched_file.details)
+            logger.warn(">>> Rotation In Progress - inode change detected and original content is not fully read, file is closed and path points to new content", :watched_file => watched_file.details)
           end
         end
         current_key = watched_file.sincedb_key
         sdb_value = @sincedb_collection.get(current_key)
         potential_key = watched_file.stat_sincedb_key
         potential_sdb_value =  @sincedb_collection.get(potential_key)
-        logger.trace(">>> Rotation In Progress", "watched_file" => watched_file.details, "found_sdb_value" => sdb_value, "potential_key" => potential_key, "potential_sdb_value" => potential_sdb_value)
+        logger.trace(">>> Rotation In Progress", :watched_file => watched_file.details, :found_sdb_value => sdb_value, :potential_key => potential_key, :potential_sdb_value => potential_sdb_value)
         if potential_sdb_value.nil?
           logger.trace("---------- >>>> Rotation In Progress: rotating as existing file")
           watched_file.rotate_as_file
@@ -200,13 +181,13 @@ module FileWatch module TailMode
             sdb_value.clear_watched_file unless sdb_value.nil?
             potential_sdb_value.set_watched_file(watched_file)
           else
-            logger.trace("---------- >>>> Rotation In Progress: rotating from...", "this watched_file details" => watched_file.details, "other watched_file details" => other_watched_file.details)
+            logger.trace("---------- >>>> Rotation In Progress: rotating from...", :this_watched_file => watched_file.details, :other_watched_file => other_watched_file.details)
             watched_file.rotate_from(other_watched_file)
             sdb_value.clear_watched_file unless sdb_value.nil?
             potential_sdb_value.set_watched_file(watched_file)
           end
         end
-        logger.trace("---------- >>>> Rotation In Progress: after handling rotation", "this watched_file details" => watched_file.details, "sincedb_value" => (potential_sdb_value || sdb_value))
+        logger.trace("---------- >>>> Rotation In Progress: after handling rotation", :this_watched_file => watched_file.details, :sincedb_value => (potential_sdb_value || sdb_value))
       end
     end
 
@@ -217,7 +198,7 @@ module FileWatch module TailMode
       #   and we allow the block to open the file and create a sincedb collection record if needed
       #   some have never been active and some have
       #   those that were active before but are watched now were closed under constraint
-      logger.trace("Watched processing")
+      logger.trace(__method__.to_s)
       # how much of the max active window is available
       to_take = @settings.max_active - watched_files.count(&:active?)
       if to_take > 0
@@ -234,14 +215,14 @@ module FileWatch module TailMode
         now = Time.now.to_i
         if (now - watch.lastwarn_max_files) > MAX_FILES_WARN_INTERVAL
           waiting = watched_files.size - @settings.max_active
-          logger.warn(@settings.max_warn_msg + ", files yet to open: #{waiting}")
+          logger.warn("#{@settings.max_warn_msg}, files yet to open: #{waiting}")
           watch.lastwarn_max_files = now
         end
       end
     end
 
     def process_active(watched_files)
-      # logger.trace("Active processing")
+      logger.trace(__method__.to_s)
       # Handles watched_files in the active state.
       # files have been opened at this point
       watched_files.each do |watched_file|
@@ -249,22 +230,22 @@ module FileWatch module TailMode
         break if watch.quit?
         path = watched_file.filename
         if watched_file.grown?
-          logger.trace("Active - file grew: #{path}: new size is #{watched_file.last_stat_size}, bytes read #{watched_file.bytes_read}")
+          logger.trace("#{__method__} file grew: new size is #{watched_file.last_stat_size}, bytes read #{watched_file.bytes_read}", :path => path)
           grow(watched_file)
         elsif watched_file.shrunk?
           if watched_file.bytes_unread > 0
-            logger.warn("Active - shrunk: DATA LOSS!! truncate detected with #{watched_file.bytes_unread} unread bytes: #{path}")
+            logger.warn("potential data loss, file truncate detected with #{watched_file.bytes_unread} unread bytes", :path => path)
           end
           # we don't update the size here, its updated when we actually read
-          logger.trace("Active - file shrunk #{path}: new size is #{watched_file.last_stat_size}, old size #{watched_file.bytes_read}")
+          logger.trace("#{__method__} file shrunk: new size is #{watched_file.last_stat_size}, old size #{watched_file.bytes_read}", :path => path)
           shrink(watched_file)
         else
           # same size, do nothing
-          logger.trace("Active - no change", "watched_file" => watched_file.details)
+          logger.trace("#{__method__} no change", :path => path)
         end
         # can any active files be closed to make way for waiting files?
         if watched_file.file_closable?
-          logger.trace("Watch each: active: file expired: #{path}")
+          logger.trace("#{__method__} file expired", :path => path)
           timeout(watched_file)
           watched_file.close
         end
@@ -284,26 +265,26 @@ module FileWatch module TailMode
       begin
         watched_file.restat
         if watched_file.rotation_in_progress?
-          logger.trace("-------------------- >>>>> restat - rotation_detected", "watched_file details" => watched_file.details, "new sincedb key" => watched_file.stat_sincedb_key)
+          logger.trace("-------------------- >>>>> restat - rotation_detected", :watched_file => watched_file.details, :new_sincedb_key => watched_file.stat_sincedb_key)
           # don't yield to closed and ignore processing
         else
           yield if block_given?
         end
       rescue Errno::ENOENT
         if delay
-          logger.trace("#{action} - delaying the stat fail on: #{watched_file.filename}")
+          logger.trace("#{action} - delaying the stat fail on", :filename => watched_file.filename)
           watched_file.delay_delete
         else
           # file has gone away or we can't read it anymore.
-          logger.trace("#{action} - after a delay, really can't find this file: #{watched_file.filename}")
+          logger.trace("#{action} - after a delay, really can't find this file", :path => watched_file.path)
           watched_file.unwatch
-          logger.trace("#{action} - removing from collection: #{watched_file.filename}")
+          logger.trace("#{action} - removing from collection", :filename => watched_file.filename)
           delete(watched_file)
-          deletable_filepaths << watched_file.path
+          add_deletable_path watched_file.path
           all_ok = false
         end
       rescue => e
-        logger.error("#{action} - other error #{watched_file.path}: (#{e.message}, #{e.backtrace.take(8).inspect})")
+        logger.error("#{action} - other error", error_details(e, watched_file))
         all_ok = false
       end
       all_ok

--- a/lib/filewatch/tail_mode/processor.rb
+++ b/lib/filewatch/tail_mode/processor.rb
@@ -21,7 +21,7 @@ module FileWatch module TailMode
   class Processor
     include LogStash::Util::Loggable
 
-    attr_reader :watch, :deletable_filepaths
+    attr_reader :watch
 
     def initialize(settings)
       @settings = settings
@@ -86,6 +86,12 @@ module FileWatch module TailMode
       process_watched(watched_files)
       return if watch.quit?
       process_active(watched_files)
+    end
+
+    def deletable_filepaths(clear: false)
+      deletable_filepaths = @deletable_filepaths
+      @deletable_filepaths = [] if clear
+      deletable_filepaths
     end
 
     private

--- a/lib/filewatch/tail_mode/processor.rb
+++ b/lib/filewatch/tail_mode/processor.rb
@@ -263,7 +263,7 @@ module FileWatch module TailMode
     def common_restat(watched_file, action, delay, &block)
       all_ok = true
       begin
-        watched_file.restat
+        restat(watched_file)
         if watched_file.rotation_in_progress?
           logger.trace("-------------------- >>>>> restat - rotation_detected", :watched_file => watched_file.details, :new_sincedb_key => watched_file.stat_sincedb_key)
           # don't yield to closed and ignore processing

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -67,8 +67,7 @@ module FileWatch
         watched_files = @watched_files_collection.values
         @processor.process_all_states(watched_files)
       ensure
-        @watched_files_collection.remove_paths(@processor.deletable_filepaths)
-        @processor.deletable_filepaths.clear
+        @watched_files_collection.remove_paths(@processor.deletable_filepaths(clear: true))
       end
     end # def each
 

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -7,21 +7,19 @@ module FileWatch
     include LogStash::Util::Loggable
 
     attr_accessor :lastwarn_max_files
-    attr_reader :discoverer, :watched_files_collection
+    attr_reader :discoverer, :processor, :watched_files_collection
 
-    def initialize(discoverer, watched_files_collection, settings)
+    def initialize(discoverer, processor, settings)
+      @discoverer = discoverer
+      @watched_files_collection = discoverer.watched_files_collection
       @settings = settings
+
       # we need to be threadsafe about the quit mutation
       @quit = Concurrent::AtomicBoolean.new(false)
       @lastwarn_max_files = 0
-      @discoverer = discoverer
-      @watched_files_collection = watched_files_collection
-    end
 
-    def add_processor(processor)
       @processor = processor
       @processor.add_watch(self)
-      self
     end
 
     def watch(path)

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -75,10 +75,7 @@ module FileWatch
     end
 
     def quit?
-      if @settings.exit_after_read
-        @exit = @watched_files_collection.empty?
-      end
-      @quit.true? || @exit
+      @quit.true? || (@settings.exit_after_read && @watched_files_collection.empty?)
     end
 
     private

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "logstash/util/loggable"
+require "concurrent/atomic/atomic_boolean"
 
 module FileWatch
   class Watch
@@ -67,9 +68,9 @@ module FileWatch
         watched_files = @watched_files_collection.values
         @processor.process_all_states(watched_files)
       ensure
-        @watched_files_collection.remove_paths(@processor.deletable_filepaths(clear: true))
+        @watched_files_collection.remove_paths(@processor.clear_deletable_paths)
       end
-    end # def each
+    end
 
     def quit
       @quit.make_true

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -121,7 +121,7 @@ module FileWatch
     end
 
     # @return whether modified_at changed since it was last read
-    # @see #restat
+    # @see #restat!
     def modified_at_changed?
       modified_at != @stat.modified_at
     end

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -16,7 +16,7 @@ module FileWatch
     def initialize(pathname, stat, settings)
       @settings = settings
       @pathname = Pathname.new(pathname) # given arg pathname might be a string or a Pathname object
-      @path = @pathname.to_path
+      @path = @pathname.to_path.freeze
       @filename = @pathname.basename.to_s
       full_state_reset(stat)
       watch

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -405,14 +405,14 @@ module FileWatch
     end
 
     def details
-      detail = "@filename='#{filename}', @state='#{state}', @recent_states='#{@recent_states.inspect}', "
-      detail.concat("@bytes_read='#{@bytes_read}', @bytes_unread='#{@bytes_unread}', current_size='#{current_size}', ")
-      detail.concat("last_stat_size='#{last_stat_size}', file_open?='#{file_open?}', @initial=#{@initial}")
-      "<FileWatch::WatchedFile: #{detail}, @sincedb_key='#{sincedb_key}'>"
+      detail = "@filename='#{@filename}', @state=#{@state.inspect}, @recent_states=#{@recent_states.inspect}, "
+      detail.concat("@bytes_read=#{@bytes_read}, @bytes_unread=#{@bytes_unread}, current_size=#{current_size}, ")
+      detail.concat("last_stat_size=#{last_stat_size}, file_open?=#{file_open?}, @initial=#{@initial}")
+      "<FileWatch::WatchedFile: #{detail}, sincedb_key='#{sincedb_key}'>"
     end
 
     def inspect
-      "\"<FileWatch::WatchedFile: @filename='#{filename}', @state='#{state}', @sincedb_key='#{sincedb_key}, size=#{@size}>\""
+      "<FileWatch::WatchedFile: @filename='#{@filename}', @state=#{@state.inspect}, current_size=#{current_size}, sincedb_key='#{sincedb_key}'>"
     end
 
     def to_s

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -99,7 +99,6 @@ module FileWatch
 
     # @return true if the file was modified since last stat
     def restat!
-      # NOTE: currently assumed to be called
       modified_at # to always be able to detect changes
       @stat.restat
       if rotation_detected?

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -24,10 +24,6 @@ module FileWatch
       set_accessed_at
     end
 
-    def no_restat_reset
-      full_state_reset(@stat)
-    end
-
     def full_state_reset(this_stat = nil)
       if this_stat.nil?
         begin
@@ -75,6 +71,7 @@ module FileWatch
       @size = @stat.size
       @sdb_key_v1 = @stat.inode_struct
     end
+    private :set_stat
 
     def rotate_as_file(bytes_read = 0)
       # rotation, when a sincedb record exists for new inode, but no watched file to rotate from

--- a/lib/filewatch/watched_files_collection.rb
+++ b/lib/filewatch/watched_files_collection.rb
@@ -3,41 +3,13 @@
 require 'java'
 
 module FileWatch
+  # @see `org.logstash.filewatch.WatchedFilesCollection`
   class WatchedFilesCollection
 
-    # @return truthy if file was added as a new mapping, falsy otherwise
-    def add(watched_file)
-      path = watched_file.path.freeze
-      synchronize do
-        prev_path = _put_file(watched_file, path)
-        @files_inverse.delete(prev_path) if prev_path
-        @files_inverse[path] = watched_file
-        prev_path
-      end
-    end
-
-    def remove_paths(paths)
-      paths = Array(paths)
-      return if paths.empty?
-      removed_files = []
-      synchronize do
-        Array(paths).each do |path|
-          file = @files_inverse.delete(path)
-          if file
-            _remove_file(file)
-            removed_files << file
-          end
-        end
-      end
-      removed_files
-    end
-
+    # Closes all managed watched files.
+    # @see FileWatch::WatchedFile#file_close
     def close_all
-      synchronize { @files.each_key(&:file_close) }
-    end
-
-    def empty?
-      synchronize { @files.empty? }
+      each_file(&:file_close) # synchronized
     end
 
     # @return [Enumerable<String>] managed path keys (snapshot)
@@ -45,12 +17,6 @@ module FileWatch
 
     # @return [Enumerable<WatchedFile>] managed files (snapshot)
     alias values files
-
-    # @param path [String] the file path
-    # @return [File] or nil if not found
-    def get(path)
-      synchronize { @files_inverse[path] }
-    end
 
   end
 end

--- a/lib/filewatch/watched_files_collection.rb
+++ b/lib/filewatch/watched_files_collection.rb
@@ -1,38 +1,15 @@
 # encoding: utf-8
 
 require 'java'
-require 'thread'
 
 module FileWatch
   class WatchedFilesCollection
 
-    def initialize(settings)
-      @sort_by = settings.file_sort_by.to_sym # "last_modified" | "path"
-      @sort_direction = settings.file_sort_direction.to_sym # "asc" | "desc"
-
-      case @sort_by
-      when :last_modified
-        sorter = @sort_direction.eql?(:desc) ?
-                     -> (l, r) { r.modified_at <=> l.modified_at } :
-                     -> (l, r) { l.modified_at <=> r.modified_at }
-      when :path
-        sorter = @sort_direction.eql?(:desc) ?
-                     -> (l, r) { r.path <=> l.path } :
-                     -> (l, r) { l.path <=> r.path }
-      else
-        raise ArgumentError, "sort_by: #{@sort_by.inspect} not supported"
-      end
-
-      @files = java.util.TreeMap.new(&sorter) # [WatchedFile] -> [String] file.path
-      @files_lock = Thread::Mutex.new
-      @files_inverse = Hash.new # keep an inverse view for fast path lookups
-    end
-
     # @return truthy if file was added as a new mapping, falsy otherwise
     def add(watched_file)
       path = watched_file.path.freeze
-      @files_lock.synchronize do
-        prev_path = @files.put(watched_file, path)
+      synchronize do
+        prev_path = _put_file(watched_file, path)
         @files_inverse.delete(prev_path) if prev_path
         @files_inverse[path] = watched_file
         prev_path
@@ -40,12 +17,14 @@ module FileWatch
     end
 
     def remove_paths(paths)
+      paths = Array(paths)
+      return if paths.empty?
       removed_files = []
-      @files_lock.synchronize do
+      synchronize do
         Array(paths).each do |path|
           file = @files_inverse.delete(path)
           if file
-            @files.remove(file)
+            _remove_file(file)
             removed_files << file
           end
         end
@@ -54,28 +33,23 @@ module FileWatch
     end
 
     def close_all
-      @files_lock.synchronize { @files.each_key(&:file_close) }
+      synchronize { @files.each_key(&:file_close) }
     end
 
     def empty?
-      @files_lock.synchronize { @files.empty? }
+      synchronize { @files.empty? }
     end
 
     # @return [Enumerable<String>] managed path keys (snapshot)
-    def keys
-      @files_lock.synchronize { @files.values.to_a }
-    end
+    alias keys paths
 
-    # @return [Enumerable<File>] managed files (snapshot)
-    def values
-      # NOTE: needs to return properly ordered files
-      @files_lock.synchronize { @files.key_set.to_a }
-    end
+    # @return [Enumerable<WatchedFile>] managed files (snapshot)
+    alias values files
 
     # @param path [String] the file path
     # @return [File] or nil if not found
     def get(path)
-      @files_lock.synchronize { @files_inverse[path] }
+      synchronize { @files_inverse[path] }
     end
 
   end

--- a/lib/filewatch/watched_files_collection.rb
+++ b/lib/filewatch/watched_files_collection.rb
@@ -1,89 +1,81 @@
 # encoding: utf-8
+
+require 'java'
+require 'thread'
+
 module FileWatch
   class WatchedFilesCollection
 
     def initialize(settings)
-      @sort_by = settings.file_sort_by # "last_modified" | "path"
-      @sort_direction = settings.file_sort_direction # "asc" | "desc"
-      @sort_method = method("#{@sort_by}_#{@sort_direction}".to_sym)
-      @files = Concurrent::Array.new
-      @pointers = Concurrent::Hash.new
+      @sort_by = settings.file_sort_by.to_sym # "last_modified" | "path"
+      @sort_direction = settings.file_sort_direction.to_sym # "asc" | "desc"
+
+      case @sort_by
+      when :last_modified
+        sorter = @sort_direction.eql?(:desc) ?
+            -> (l, r) { r.modified_at <=> l.modified_at } :
+            -> (l, r) { l.modified_at <=> r.modified_at }
+      when :path
+        sorter = @sort_direction.eql?(:desc) ?
+            -> (l, r) { r.path <=> l.path } :
+            -> (l, r) { l.path <=> r.path }
+      else
+        raise ArgumentError, "sort_by: #{@sort_by.inspect} not supported"
+      end
+
+      @files = java.util.TreeMap.new(&sorter) # [File] -> [String] file.path
+      @files_lock = Thread::Mutex.new
     end
 
     def add(watched_file)
-      @files << watched_file
-      @sort_method.call
+      @files_lock.synchronize { !@files.put(watched_file, watched_file.path).nil? }
     end
 
     def remove_paths(paths)
-      removed_files = Array(paths).map do |path|
-        index = @pointers.delete(path)
-        if index
-          watched_file = @files.delete_at(index)
-          refresh_pointers
-          watched_file
+      removed_files = []
+      @files_lock.synchronize do
+        Array(paths).each do |path|
+          entry = file_for_path(path)
+          if entry
+            watched_file = entry.key
+            @files.remove(watched_file)
+            removed_files << watched_file
+          end
         end
       end
-      @sort_method.call
       removed_files
     end
 
     def close_all
-      @files.each(&:file_close)
+      @files_lock.synchronize { @files.each_key(&:file_close) }
     end
 
     def empty?
-      @files.empty?
+      @files_lock.synchronize { @files.empty? }
     end
 
+    # @return [Enumerable<String>] managed path keys (snapshot)
     def keys
-      @pointers.keys
+      @files_lock.synchronize { @files.values.to_a }
     end
 
+    # @return [Enumerable<File>] managed files (snapshot)
     def values
-      @files
+      @files_lock.synchronize { @files.key_set.to_a }
     end
 
-    def watched_file_by_path(path)
-      index = @pointers[path]
-      return nil unless index
-      @files[index]
+    # @param path [String] the file path
+    # @return [File] or nil if not found
+    def get(path)
+      @files_lock.synchronize { file_for_path(path) }
     end
 
     private
 
-    def last_modified_asc
-      @files.sort! do |left, right|
-        left.modified_at <=> right.modified_at
-      end
-      refresh_pointers
+    def file_for_path(path)
+      entry = @files.entry_set.find { |_, val| val == path }
+      entry && entry.key
     end
 
-    def last_modified_desc
-      @files.sort! do |left, right|
-        right.modified_at <=> left.modified_at
-      end
-      refresh_pointers
-    end
-
-    def path_asc
-      @files.sort! do |left, right|
-        left.path <=> right.path
-      end
-      refresh_pointers
-    end
-
-    def path_desc
-      @files.sort! do |left, right|
-        right.path <=> left.path
-      end
-      refresh_pointers
-    end
-
-    def refresh_pointers
-      @files.each_with_index do |watched_file, index|
-        @pointers[watched_file.path] = index
-      end
-    end
   end
 end

--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -332,8 +332,9 @@ class File < LogStash::Inputs::Base
     @completely_stopped.true?
   end
 
+  # The WatchedFile calls back here as `observer.listener_for(@path)`
+  # @param [String] path the identity
   def listener_for(path)
-    # path is the identity
     FileListener.new(path, self)
   end
 

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency 'addressable'
   end
 
+  s.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-multiline', ['~> 3.0']
 
   s.add_development_dependency 'stud', ['~> 0.0.19']

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.18'
+  s.version         = '4.2.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filewatch/settings_spec.rb
+++ b/spec/filewatch/settings_spec.rb
@@ -1,3 +1,6 @@
+require 'logstash/devutils/rspec/spec_helper'
+require 'logstash/inputs/friendly_durations'
+
 describe FileWatch::Settings do
 
   context "when create from options" do

--- a/spec/filewatch/watched_files_collection_spec.rb
+++ b/spec/filewatch/watched_files_collection_spec.rb
@@ -4,12 +4,12 @@ require_relative 'spec_helper'
 module FileWatch
   describe WatchedFilesCollection do
     let(:time) { Time.now }
-    let(:filepath1){"/var/log/z.log"}
-    let(:filepath2){"/var/log/m.log"}
-    let(:filepath3){"/var/log/a.log"}
-    let(:stat1)  { double("stat1", :size => 98, :modified_at => time - 30, :identifier => nil, :inode => 234567, :inode_struct => InodeStruct.new("234567", 3, 2)) }
-    let(:stat2)  { double("stat2", :size => 99, :modified_at => time - 20, :identifier => nil, :inode => 234568, :inode_struct => InodeStruct.new("234568", 3, 2)) }
-    let(:stat3)  { double("stat3", :size => 100, :modified_at => time, :identifier => nil, :inode => 234569, :inode_struct => InodeStruct.new("234569", 3, 2)) }
+    let(:filepath1) { "/var/log/z.log" }
+    let(:filepath2) { "/var/log/m.log" }
+    let(:filepath3) { "/var/log/a.log" }
+    let(:stat1) { double("stat1", :size => 98, :modified_at => time - 30, :inode => 234567, :inode_struct => InodeStruct.new("234567", 3, 2)) }
+    let(:stat2) { double("stat2", :size => 99, :modified_at => time - 20, :inode => 234568, :inode_struct => InodeStruct.new("234568", 3, 2)) }
+    let(:stat3) { double("stat3", :size => 100, :modified_at => time, :inode => 234569, :inode_struct => InodeStruct.new("234569", 3, 2)) }
     let(:wf1) { WatchedFile.new(filepath1, stat1, Settings.new) }
     let(:wf2) { WatchedFile.new(filepath2, stat2, Settings.new) }
     let(:wf3) { WatchedFile.new(filepath3, stat3, Settings.new) }

--- a/spec/filewatch/watched_files_collection_spec.rb
+++ b/spec/filewatch/watched_files_collection_spec.rb
@@ -7,12 +7,15 @@ module FileWatch
     let(:filepath1) { "/var/log/z.log" }
     let(:filepath2) { "/var/log/m.log" }
     let(:filepath3) { "/var/log/a.log" }
+    let(:filepath4) { "/var/log/b.log" }
     let(:stat1) { double("stat1", :size => 98, :modified_at => time - 30, :inode => 234567, :inode_struct => InodeStruct.new("234567", 3, 2)) }
     let(:stat2) { double("stat2", :size => 99, :modified_at => time - 20, :inode => 234568, :inode_struct => InodeStruct.new("234568", 3, 2)) }
     let(:stat3) { double("stat3", :size => 100, :modified_at => time, :inode => 234569, :inode_struct => InodeStruct.new("234569", 3, 2)) }
+    let(:stat4) { double("stat4", :size => 99, :modified_at => time, :inode => 234570, :inode_struct => InodeStruct.new("234570", 3, 2)) }
     let(:wf1) { WatchedFile.new(filepath1, stat1, Settings.new) }
     let(:wf2) { WatchedFile.new(filepath2, stat2, Settings.new) }
     let(:wf3) { WatchedFile.new(filepath3, stat3, Settings.new) }
+    let(:wf4) { WatchedFile.new(filepath4, stat4, Settings.new) }
 
     context "sort by last_modified in ascending order" do
       let(:sort_by) { "last_modified" }
@@ -20,12 +23,29 @@ module FileWatch
 
       it "sorts earliest modified first" do
         collection = described_class.new(Settings.from_options(:file_sort_by => sort_by, :file_sort_direction => sort_direction))
+        expect(collection.empty?).to be true
         collection.add(wf2)
+        expect(collection.empty?).to be false
         expect(collection.values).to eq([wf2])
         collection.add(wf3)
         expect(collection.values).to eq([wf2, wf3])
         collection.add(wf1)
         expect(collection.values).to eq([wf1, wf2, wf3])
+        expect(collection.keys.size).to eq 3
+      end
+
+      it "sorts by path when mtime is same" do
+        collection = described_class.new(Settings.from_options(:file_sort_by => sort_by, :file_sort_direction => sort_direction))
+        expect(collection.size).to eq 0
+        collection.add(wf2)
+        collection.add(wf4)
+        collection.add(wf1)
+        expect(collection.size).to eq 3
+        expect(collection.values).to eq([wf1, wf2, wf4])
+        collection.add(wf3)
+        expect(collection.size).to eq 4
+        expect(collection.values).to eq([wf1, wf2, wf3, wf4])
+        expect(collection.keys.size).to eq 4
       end
     end
 
@@ -74,7 +94,7 @@ module FileWatch
       end
     end
 
-    context "when delete called" do
+    context "remove_paths" do
       let(:sort_by) { "path" }
       let(:sort_direction) { "desc" }
 
@@ -85,9 +105,43 @@ module FileWatch
         collection.add(wf3)
         expect(collection.keys).to eq([filepath1, filepath2, filepath3])
 
-        collection.remove_paths([filepath2,filepath3])
+        ret = collection.remove_paths([filepath2, filepath3])
+        expect(ret).to eq 2
         expect(collection.keys).to eq([filepath1])
         expect(collection.values.size).to eq 1
+
+        ret = collection.remove_paths([filepath2])
+        expect(ret).to eq 0
+      end
+    end
+
+    context "update" do
+      let(:sort_by) { "last_modified" }
+      let(:sort_direction) { "asc" }
+
+      let(:re_stat1) { double("restat1", :size => 99, :modified_at => time, :inode => 234567, :inode_struct => InodeStruct.new("234567", 3, 2)) }
+      let(:re_stat2) { double("restat2", :size => 99, :modified_at => time, :inode => 234568, :inode_struct => InodeStruct.new("234568", 3, 2)) }
+
+      it "updates entry with changed mtime" do
+        collection = described_class.new(Settings.from_options(:file_sort_by => sort_by, :file_sort_direction => sort_direction))
+        collection.add(wf1)
+        collection.add(wf2)
+        collection.add(wf3)
+        expect(collection.files).to eq([wf1, wf2, wf3])
+
+        wf2.send(:set_stat, re_stat2)
+        expect( wf2.modified_at_changed? ).to be_truthy
+
+        collection.update wf2
+        expect(collection.files).to eq([wf1, wf3, wf2])
+
+        wf1.send(:set_stat, re_stat1)
+        expect( wf1.modified_at_changed? ).to be_truthy
+        collection.update wf1
+        expect(collection.files).to eq([wf3, wf2, wf1])
+
+        collection.add(wf4)
+        expect(collection.files).to eq([wf3, wf4, wf2, wf1])
       end
     end
 

--- a/src/main/java/org/logstash/filewatch/JrubyFileWatchLibrary.java
+++ b/src/main/java/org/logstash/filewatch/JrubyFileWatchLibrary.java
@@ -84,6 +84,7 @@ public class JrubyFileWatchLibrary implements Library {
         clazz = runtime.defineClassUnder("Fnv", runtime.getObject(), JrubyFileWatchLibrary.Fnv::new, module);
         clazz.defineAnnotatedMethods(JrubyFileWatchLibrary.Fnv.class);
 
+        WatchedFilesCollection.load(runtime);
     }
 
     @JRubyClass(name = "FileExt")

--- a/src/main/java/org/logstash/filewatch/WatchedFilesCollection.java
+++ b/src/main/java/org/logstash/filewatch/WatchedFilesCollection.java
@@ -70,9 +70,15 @@ public class WatchedFilesCollection extends RubyObject {
             default :
                 throw context.runtime.newArgumentError("sort_by: '" + sort_by + "' not supported");
         }
-
-        if ("desc".equals(sort_direction)) {
-            comparator = comparator.reversed();
+        switch (sort_direction) {
+            case "asc" :
+                // all good - comparator uses ascending order
+                break;
+            case "desc" :
+                comparator = comparator.reversed();
+                break;
+            default :
+                throw context.runtime.newArgumentError("sort_direction: '" + sort_direction + "' not supported");
         }
 
         this.files = new TreeMap<>(comparator);

--- a/src/main/java/org/logstash/filewatch/WatchedFilesCollection.java
+++ b/src/main/java/org/logstash/filewatch/WatchedFilesCollection.java
@@ -1,13 +1,14 @@
 package org.logstash.filewatch;
 
 import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFloat;
 import org.jruby.RubyHash;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -20,16 +21,18 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
- * FileWatch::WatchedFilesCollection (native) part.
+ * FileWatch::WatchedFilesCollection for managing paths mapped to (watched) files.
  *
- * Implemented here to avoid Ruby->Java type casting (which JRuby provides no control of as of 9.2)
- * We could have used Ruby's SortedSet but it does not provide support for custom comparators.
+ * Implemented in native to avoid Ruby->Java type casting (which JRuby provides no control of as of 9.2).
+ * The collection already has a noticeable footprint when 10_000s of files are being watched at once, having
+ * the implementation in Java reduces 1000s of String conversions on every watch re-stat tick.
  */
 public class WatchedFilesCollection extends RubyObject {
 
+    // we could have used Ruby's SortedSet but it does not provide support for custom comparators
     private SortedMap<IRubyObject, RubyString> files; // FileWatch::WatchedFile -> String
-    private RubyHash filesInverse;
-    private transient CachingCallSite watchedFileSite;
+    private RubyHash filesInverse; // String -> FileWatch::WatchedFile
+    private String sortBy;
 
     public WatchedFilesCollection(Ruby runtime, RubyClass metaClass) {
         super(runtime, metaClass);
@@ -46,24 +49,23 @@ public class WatchedFilesCollection extends RubyObject {
         final String sort_by = settings.callMethod(context, "file_sort_by").asJavaString();
         final String sort_direction = settings.callMethod(context, "file_sort_direction").asJavaString();
 
-        final String method;
         Comparator<IRubyObject> comparator;
         switch (sort_by) {
             case "last_modified" :
-                method = "modified_at";
+                sortBy = "modified_at";
                 comparator = (file1, file2) -> {
-                    RubyFloat mtime1 = watchedFileCallMethod(context, file1).convertToFloat();
-                    RubyFloat mtime2 = watchedFileCallMethod(context, file2).convertToFloat();
-                    return Double.compare(mtime1.getDoubleValue(), mtime2.getDoubleValue());
+                    if (file1 == file2) return 0; // fast shortcut
+                    RubyFloat mtime1 = modified_at(context, file1);
+                    RubyFloat mtime2 = modified_at(context, file2);
+                    int cmp = Double.compare(mtime1.getDoubleValue(), mtime2.getDoubleValue());
+                    // if mtime same (rare unless file1 == file2) - order consistently
+                    if (cmp == 0) return path(context, file1).op_cmp(path(context, file2));
+                    return cmp;
                 };
                 break;
             case "path" :
-                method = "path";
-                comparator = (file1, file2) -> {
-                    RubyString path1 = watchedFileCallMethod(context, file1).convertToString();
-                    RubyString path2 = watchedFileCallMethod(context, file2).convertToString();
-                    return path1.op_cmp(path2);
-                };
+                sortBy = "path";
+                comparator = (file1, file2) -> path(context, file1).op_cmp(path(context, file2));
                 break;
             default :
                 throw context.runtime.newArgumentError("sort_by: '" + sort_by + "' not supported");
@@ -73,50 +75,155 @@ public class WatchedFilesCollection extends RubyObject {
             comparator = comparator.reversed();
         }
 
-        this.watchedFileSite = new FunctionalCachingCallSite(method);
-
         this.files = new TreeMap<>(comparator);
         this.filesInverse = RubyHash.newHash(context.runtime);
 
-        variableTableStore("@files", JavaUtil.convertJavaToRuby(context.runtime, this.files));
-        variableTableStore("@files_inverse", this.filesInverse);
+        // variableTableStore("@files", JavaUtil.convertJavaToRuby(context.runtime, this.files));
+        // variableTableStore("@files_inverse", this.filesInverse);
 
         return this;
     }
 
+    @JRubyMethod
+    public IRubyObject add(ThreadContext context, IRubyObject file) {
+        RubyString path = getFilePath(context, file);
+        synchronized (this) {
+            RubyString prev_path = this.files.put(file, path);
+            assert prev_path == null || path.equals(prev_path); // file's path should not change!
+            this.filesInverse.op_aset(context, path, file);
+        }
+        return path;
+    }
+
+    private static RubyString getFilePath(ThreadContext context, IRubyObject file) {
+        IRubyObject path = file.callMethod(context, "path");
+        if (!(path instanceof RubyString)) {
+            throw context.runtime.newTypeError("expected file.path to return String but did not file: " + file.inspect());
+        }
+        if (!path.isFrozen()) path = ((RubyString) path).dupFrozen(); // path = path.dup.freeze
+        return (RubyString) path;
+    }
+
+    @JRubyMethod
+    public IRubyObject remove_paths(ThreadContext context, IRubyObject arg) {
+        IRubyObject[] paths;
+        if (arg instanceof RubyArray) {
+            paths = ((RubyArray) arg).toJavaArray();
+        } else {
+            paths = new IRubyObject[] { arg };
+        }
+
+        int removedCount = 0;
+        synchronized (this) {
+            for (final IRubyObject path : paths) {
+                if (removePath(context, path.convertToString())) removedCount++;
+            }
+        }
+        return context.runtime.newFixnum(removedCount);
+    }
+
+    private boolean removePath(ThreadContext context, RubyString path) {
+        IRubyObject file = this.filesInverse.delete(context, path, Block.NULL_BLOCK);
+        if (file.isNil()) return false;
+        return this.files.remove(file) != null;
+    }
+
+    @JRubyMethod // synchronize { @files_inverse[path] }
+    public synchronized IRubyObject get(ThreadContext context, IRubyObject path) {
+        return this.filesInverse.op_aref(context, path);
+    }
+
+    @JRubyMethod // synchronize { @files.size }
+    public synchronized IRubyObject size(ThreadContext context) {
+        return context.runtime.newFixnum(this.files.size());
+    }
+
+    @JRubyMethod(name = "empty?") // synchronize { @files.empty? }
+    public synchronized IRubyObject empty_p(ThreadContext context) {
+        return context.runtime.newBoolean(this.files.isEmpty());
+    }
+
+    @JRubyMethod
+    public synchronized IRubyObject each_file(ThreadContext context, Block block) {
+        for (IRubyObject watched_file : this.files.keySet()) {
+            block.yield(context, watched_file);
+        }
+        return context.nil;
+    }
+
     @JRubyMethod // synchronize { @files.values.to_a }
-    public synchronized IRubyObject paths(ThreadContext context) {
-        IRubyObject[] values = this.files.values().stream().toArray(IRubyObject[]::new);
+    public IRubyObject paths(ThreadContext context) {
+        IRubyObject[] values;
+        synchronized (this) {
+            values = this.files.values().stream().toArray(IRubyObject[]::new);
+        }
         return context.runtime.newArrayNoCopy(values);
     }
 
     // NOTE: needs to return properly ordered files (can not use @files_inverse)
     @JRubyMethod // synchronize { @files.key_set.to_a }
-    public synchronized IRubyObject files(ThreadContext context) {
-        IRubyObject[] keys = this.files.keySet().stream().toArray(IRubyObject[]::new);
+    public IRubyObject files(ThreadContext context) {
+        IRubyObject[] keys;
+        synchronized (this) {
+            keys = this.files.keySet().stream().toArray(IRubyObject[]::new);
+        }
         return context.runtime.newArrayNoCopy(keys);
     }
 
-    // internal helpers for the rest of watched_file_collection.rb :
 
-    @JRubyMethod(visibility = Visibility.PRIVATE)
-    public IRubyObject _put_file(ThreadContext context, IRubyObject file, IRubyObject path) {
-        RubyString prev_path = this.files.put(file, (RubyString) path);
-        return prev_path == null ? context.nil : prev_path;
+    @JRubyMethod
+    public IRubyObject update(ThreadContext context, IRubyObject file) {
+        // NOTE: modified_at might change on restat - to cope with that we need to potentially
+        // update the sorted collection, on such changes (when file_sort_by: last_modified) :
+        if (!"modified_at".equals(sortBy)) return context.nil;
+
+        RubyString path = getFilePath(context, file);
+        synchronized (this) {
+            this.files.remove(file); // we need to "re-sort" changed file -> remove and add it back
+            modified_at(context, file, context.tru); // file.modified_at(update: true)
+            RubyString prev_path = this.files.put(file, path);
+            assert prev_path == null;
+        }
+        return context.tru;
     }
 
-    @JRubyMethod(visibility = Visibility.PRIVATE)
-    public IRubyObject _remove_file(ThreadContext context, IRubyObject file) {
-        IRubyObject removed = this.files.remove(file);
-        return removed == null ? context.nil : removed;
+    @JRubyMethod(required = 1, visibility = Visibility.PRIVATE)
+    @Override
+    public IRubyObject initialize_copy(IRubyObject original) {
+        final Ruby runtime = getRuntime();
+        if (!(original instanceof WatchedFilesCollection)) {
+            throw runtime.newTypeError("Expecting an instance of class WatchedFilesCollection");
+        }
+
+        WatchedFilesCollection proto = (WatchedFilesCollection) original;
+
+        this.files = new TreeMap<>(proto.files.comparator());
+        synchronized (proto) {
+            this.files.putAll(proto.files);
+            this.filesInverse = (RubyHash) proto.filesInverse.dup(runtime.getCurrentContext());
+        }
+
+        return this;
     }
 
-    @JRubyMethod(visibility = Visibility.PRIVATE)
-    public IRubyObject synchronize(ThreadContext context, Block block) {
-        synchronized (this) { return block.yield(context, this); }
+    @Override
+    public IRubyObject inspect() {
+        return getRuntime().newString("#<" + metaClass.getRealClass().getName() + ": size=" + this.files.size() + ">");
     }
 
-    private IRubyObject watchedFileCallMethod(ThreadContext context, IRubyObject watched_file) {
-        return watchedFileSite.call(context, watched_file, watched_file);
+    private static final CachingCallSite modified_at_site = new FunctionalCachingCallSite("modified_at");
+    private static final CachingCallSite path_site = new FunctionalCachingCallSite("path");
+
+    private static RubyString path(ThreadContext context, IRubyObject watched_file) {
+        return path_site.call(context, watched_file, watched_file).convertToString();
     }
+
+    private static RubyFloat modified_at(ThreadContext context, IRubyObject watched_file) {
+        return modified_at_site.call(context, watched_file, watched_file).convertToFloat();
+    }
+
+    private static RubyFloat modified_at(ThreadContext context, IRubyObject watched_file, RubyBoolean update) {
+        return modified_at_site.call(context, watched_file, watched_file, update).convertToFloat();
+    }
+
 }

--- a/src/main/java/org/logstash/filewatch/WatchedFilesCollection.java
+++ b/src/main/java/org/logstash/filewatch/WatchedFilesCollection.java
@@ -1,0 +1,122 @@
+package org.logstash.filewatch;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyFloat;
+import org.jruby.RubyHash;
+import org.jruby.RubyObject;
+import org.jruby.RubyString;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Visibility;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.callsite.CachingCallSite;
+import org.jruby.runtime.callsite.FunctionalCachingCallSite;
+
+import java.util.Comparator;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * FileWatch::WatchedFilesCollection (native) part.
+ *
+ * Implemented here to avoid Ruby->Java type casting (which JRuby provides no control of as of 9.2)
+ * We could have used Ruby's SortedSet but it does not provide support for custom comparators.
+ */
+public class WatchedFilesCollection extends RubyObject {
+
+    private SortedMap<IRubyObject, RubyString> files; // FileWatch::WatchedFile -> String
+    private RubyHash filesInverse;
+    private transient CachingCallSite watchedFileSite;
+
+    public WatchedFilesCollection(Ruby runtime, RubyClass metaClass) {
+        super(runtime, metaClass);
+    }
+
+    static void load(Ruby runtime) {
+        runtime.getOrCreateModule("FileWatch")
+               .defineClassUnder("WatchedFilesCollection", runtime.getObject(), WatchedFilesCollection::new)
+               .defineAnnotatedMethods(WatchedFilesCollection.class);
+    }
+
+    @JRubyMethod
+    public IRubyObject initialize(final ThreadContext context, IRubyObject settings) {
+        final String sort_by = settings.callMethod(context, "file_sort_by").asJavaString();
+        final String sort_direction = settings.callMethod(context, "file_sort_direction").asJavaString();
+
+        final String method;
+        Comparator<IRubyObject> comparator;
+        switch (sort_by) {
+            case "last_modified" :
+                method = "modified_at";
+                comparator = (file1, file2) -> {
+                    RubyFloat mtime1 = watchedFileCallMethod(context, file1).convertToFloat();
+                    RubyFloat mtime2 = watchedFileCallMethod(context, file2).convertToFloat();
+                    return Double.compare(mtime1.getDoubleValue(), mtime2.getDoubleValue());
+                };
+                break;
+            case "path" :
+                method = "path";
+                comparator = (file1, file2) -> {
+                    RubyString path1 = watchedFileCallMethod(context, file1).convertToString();
+                    RubyString path2 = watchedFileCallMethod(context, file2).convertToString();
+                    return path1.op_cmp(path2);
+                };
+                break;
+            default :
+                throw context.runtime.newArgumentError("sort_by: '" + sort_by + "' not supported");
+        }
+
+        if ("desc".equals(sort_direction)) {
+            comparator = comparator.reversed();
+        }
+
+        this.watchedFileSite = new FunctionalCachingCallSite(method);
+
+        this.files = new TreeMap<>(comparator);
+        this.filesInverse = RubyHash.newHash(context.runtime);
+
+        variableTableStore("@files", JavaUtil.convertJavaToRuby(context.runtime, this.files));
+        variableTableStore("@files_inverse", this.filesInverse);
+
+        return this;
+    }
+
+    @JRubyMethod // synchronize { @files.values.to_a }
+    public synchronized IRubyObject paths(ThreadContext context) {
+        IRubyObject[] values = this.files.values().stream().toArray(IRubyObject[]::new);
+        return context.runtime.newArrayNoCopy(values);
+    }
+
+    // NOTE: needs to return properly ordered files (can not use @files_inverse)
+    @JRubyMethod // synchronize { @files.key_set.to_a }
+    public synchronized IRubyObject files(ThreadContext context) {
+        IRubyObject[] keys = this.files.keySet().stream().toArray(IRubyObject[]::new);
+        return context.runtime.newArrayNoCopy(keys);
+    }
+
+    // internal helpers for the rest of watched_file_collection.rb :
+
+    @JRubyMethod(visibility = Visibility.PRIVATE)
+    public IRubyObject _put_file(ThreadContext context, IRubyObject file, IRubyObject path) {
+        RubyString prev_path = this.files.put(file, (RubyString) path);
+        return prev_path == null ? context.nil : prev_path;
+    }
+
+    @JRubyMethod(visibility = Visibility.PRIVATE)
+    public IRubyObject _remove_file(ThreadContext context, IRubyObject file) {
+        IRubyObject removed = this.files.remove(file);
+        return removed == null ? context.nil : removed;
+    }
+
+    @JRubyMethod(visibility = Visibility.PRIVATE)
+    public IRubyObject synchronize(ThreadContext context, Block block) {
+        synchronized (this) { return block.yield(context, this); }
+    }
+
+    private IRubyObject watchedFileCallMethod(ThreadContext context, IRubyObject watched_file) {
+        return watchedFileSite.call(context, watched_file, watched_file);
+    }
+}


### PR DESCRIPTION
Plugin tracks all discovered files in a map-like collection (`FileWatch::WatchedFilesCollection`).
The collection design was to re-sort all elements every time the collection gets updated ... this obviously does not scale with 10000s of watched files. 
Starting up LS with 60k files in a watched directory, locally, takes **\~ an hour before these changes**.
**After these changes** for the plugin to start processing files it takes  **~2 seconds**.

Since the collection is known to have a noticeable (memory) footprint, there's changes towards reducing intermediate garbage - which also contributed to the decision to move the collection to native.

Notable changes to tracking watched files with `FileWatch::WatchedFilesCollection`:
- predictable `log(size)` modification (and access) times
- implementation has clear locking semantics, previously operations weren't 100% atomic
- hopefully, cleaner API as the collection re-resembles a *WatchedFile -> String (path)* map
- the collection now needs an explicit update whenever a file changes (on re-stat),
  previous implicitness of picking up changes might have been the reasoning behind re-sorts
  (could be decoupled further by making `WatchedFile` immutable but there's other state anyway)

---

Apart from the necessary changes to resolve the performance bottleneck, there's also a quick review of (trace) logging - annoying to not only see partial traces even in debug/trace levels.

Few unused methods and instance variables were removed for a better code reading experience.
