### PR TITLE
Fix: release watched files on completion (in read-mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.18
+  - Fix: release watched files on completion (in read-mode) [#271](https://github.com/logstash-plugins/logstash-input-file/pull/271)
+
 ## 4.1.17
   - Added configuration setting `check_archive_validity` settings to enable
   gzipped files verification, issue

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -22,6 +22,9 @@ module FileWatch module ReadMode module Handlers
           sincedb_collection.reading_completed(key)
           sincedb_collection.clear_watched_file(key)
           watched_file.listener.deleted
+          # NOTE: on top of un-watching we should also remove from the watched files collection
+          # if the file is getting deleted (on completion), that part currently resides in
+          # DeleteCompletedFileHandler - triggered above using `watched_file.listener.deleted`
           watched_file.unwatch
         end
       end

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -67,7 +67,7 @@ module FileWatch
         watched_files = @watched_files_collection.values
         @processor.process_all_states(watched_files)
       ensure
-        @watched_files_collection.delete(@processor.deletable_filepaths)
+        @watched_files_collection.remove_paths(@processor.deletable_filepaths)
         @processor.deletable_filepaths.clear
       end
     end # def each

--- a/lib/filewatch/watched_files_collection.rb
+++ b/lib/filewatch/watched_files_collection.rb
@@ -15,13 +15,17 @@ module FileWatch
       @sort_method.call
     end
 
-    def delete(paths)
-      Array(paths).each do |f|
-        index = @pointers.delete(f)
-        @files.delete_at(index)
-        refresh_pointers
+    def remove_paths(paths)
+      removed_files = Array(paths).map do |path|
+        index = @pointers.delete(path)
+        if index
+          watched_file = @files.delete_at(index)
+          refresh_pointers
+          watched_file
+        end
       end
       @sort_method.call
+      removed_files
     end
 
     def close_all

--- a/lib/logstash/inputs/delete_completed_file_handler.rb
+++ b/lib/logstash/inputs/delete_completed_file_handler.rb
@@ -2,8 +2,13 @@
 
 module LogStash module Inputs
   class DeleteCompletedFileHandler
+    def initialize(watch)
+      @watch = watch
+    end
+
     def handle(path)
       Pathname.new(path).unlink rescue nil
+      @watch.watched_files_collection.remove_paths([path])
     end
   end
 end end

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.1.17'
+  s.version         = '4.1.18'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filewatch/watched_files_collection_spec.rb
+++ b/spec/filewatch/watched_files_collection_spec.rb
@@ -85,9 +85,9 @@ module FileWatch
         collection.add(wf3)
         expect(collection.keys).to eq([filepath1, filepath2, filepath3])
 
-        collection.delete([filepath2,filepath3])
+        collection.remove_paths([filepath2,filepath3])
         expect(collection.keys).to eq([filepath1])
-
+        expect(collection.values.size).to eq 1
       end
     end
 

--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require "logstash/devutils/rspec/spec_helper"
+require "rspec/wait"
 require "rspec_sequencing"
 
 module FileInput

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -296,7 +296,8 @@ describe LogStash::Inputs::File do
 
     it 'removes watched file from collection' do
       wait_for_file_removal(sample_file) # watched discovery
-
+      sleep(0.25) # give CI some space to execute the removal
+      # TODO shouldn't be necessary once WatchedFileCollection does proper locking
       watched_files = plugin.watcher.watch.watched_files_collection
       expect( watched_files ).to be_empty
     end
@@ -307,6 +308,7 @@ describe LogStash::Inputs::File do
       begin
         Timeout.timeout(timeout) do
           sleep(0.01) while run_thread.status != 'sleep'
+          sleep(timeout) unless plugin.queue
         end
       rescue Timeout::Error
         raise "plugin did not start processing (timeout: #{timeout})" unless plugin.queue

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -317,7 +317,6 @@ describe LogStash::Inputs::File do
 
     def wait_for_file_removal(path, timeout: 3 * interval)
       wait(timeout).for { File.exist?(path) }.to be_falsey
-      raise "plugin did not start processing" unless plugin.queue
     end
 
   end

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -247,4 +247,78 @@ describe LogStash::Inputs::File do
       end
     end
   end
+
+  let(:temp_directory) { Stud::Temporary.directory }
+  let(:interval) { 0.1 }
+  let(:options) do
+    {
+        'mode' => "read",
+        'path' => "#{temp_directory}/*",
+        'stat_interval' => interval,
+        'discover_interval' => interval,
+        'sincedb_path' => "#{temp_directory}/.sincedb",
+        'sincedb_write_interval' => interval
+    }
+  end
+
+  let(:queue) { Queue.new }
+  let(:plugin) { LogStash::Inputs::File.new(options) }
+
+  describe 'delete on complete' do
+
+    let(:options) do
+      super.merge({ 'file_completed_action' => "delete", 'exit_after_read' => false })
+    end
+
+    let(:sample_file) { File.join(temp_directory, "sample.log") }
+
+    before do
+      plugin.register
+      @run_thread = Thread.new(plugin) do |plugin|
+        Thread.current.abort_on_exception = true
+        plugin.run queue
+      end
+
+      File.open(sample_file, 'w') { |fd| fd.write("sample-content\n") }
+
+      wait_for_start_processing(@run_thread)
+    end
+
+    after { plugin.stop }
+
+    it 'processes a file' do
+      wait_for_file_removal(sample_file) # watched discovery
+
+      expect( plugin.queue.size ).to eql 1
+      event = plugin.queue.pop
+      expect( event.get('message') ).to eql 'sample-content'
+    end
+
+    it 'removes watched file from collection' do
+      wait_for_file_removal(sample_file) # watched discovery
+
+      watched_files = plugin.watcher.watch.watched_files_collection
+      expect( watched_files ).to be_empty
+    end
+
+    private
+
+    def wait_for_start_processing(run_thread, timeout: 1.0)
+      begin
+        Timeout.timeout(timeout) do
+          sleep(0.01) while run_thread.status != 'sleep'
+        end
+      rescue Timeout::Error
+        raise "plugin did not start processing (timeout: #{timeout})" unless plugin.queue
+      else
+        raise "plugin did not start processing" unless plugin.queue
+      end
+    end
+
+    def wait_for_file_removal(path, timeout: 3 * interval)
+      wait(timeout).for { File.exist?(path) }.to be_falsey
+      raise "plugin did not start processing" unless plugin.queue
+    end
+
+  end
 end


### PR DESCRIPTION
not doing so leads to a steady increase in watched collection's size
over time (esp. in use-cases where user is pulling in new files).

the left-over watched file entry is never to be processed again - it's being deleted anyway (assuming `'file_completed_action' => "delete"`) using the completion handler.

resolves https://github.com/logstash-plugins/logstash-input-file/issues/270

*NOTE: please ignore the **existing** potential atomicity issues in the watched file collection a follow-up on this PR will deal with a `WatchedFileCollection` rewrite*
