### PR TITLE
Fix: sincedb_clean_after not being respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.2
+  - Fix: sincedb_clean_after not being respected [#276](https://github.com/logstash-plugins/logstash-input-file/pull/276)
+
 ## 4.2.1
   - Fix: skip sincedb eviction if read mode completion deletes file during flush [#273](https://github.com/logstash-plugins/logstash-input-file/pull/273)
   

--- a/lib/filewatch/observing_base.rb
+++ b/lib/filewatch/observing_base.rb
@@ -83,15 +83,5 @@ module FileWatch
       # sincedb_write("shutting down")
     end
 
-    # close_file(path) is to be used by external code
-    # when it knows that it is completely done with a file.
-    # Other files or folders may still be being watched.
-    # Caution, once unwatched, a file can't be watched again
-    # unless a new instance of this class begins watching again.
-    # The sysadmin should rename, move or delete the file.
-    def close_file(path)
-      @watch.unwatch(path)
-      sincedb_write
-    end
   end
 end

--- a/lib/filewatch/sincedb_collection.rb
+++ b/lib/filewatch/sincedb_collection.rb
@@ -180,8 +180,6 @@ module FileWatch
       get(key).watched_file.nil?
     end
 
-    private
-
     def flush_at_interval
       now = Time.now
       delta = now.to_i - @sincedb_last_write
@@ -190,6 +188,8 @@ module FileWatch
         sincedb_write(now)
       end
     end
+
+    private
 
     def handle_association(sincedb_value, watched_file)
       watched_file.update_bytes_read(sincedb_value.position)

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -51,7 +51,10 @@ module FileWatch
           glob = 0
         end
         break if quit?
+        # NOTE: maybe the plugin should validate stat_interval <= sincedb_write_interval <= sincedb_clean_after
         sleep(@settings.stat_interval)
+        # we need to check potential expired keys (sincedb_clean_after) periodically
+        sincedb_collection.flush_at_interval
       end
       sincedb_collection.write_if_requested # does nothing if no requests to write were lodged.
       @watched_files_collection.close_all

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.2.1'
+  s.version         = '4.2.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -309,7 +309,7 @@ describe LogStash::Inputs::File do
       super.merge(
           'sincedb_path' => sincedb_path,
           'sincedb_clean_after' => '1.0 seconds',
-          'sincedb_write_interval' => 0.5,
+          'sincedb_write_interval' => 0.25,
           'stat_interval' => 0.1,
       )
     end
@@ -338,10 +338,12 @@ describe LogStash::Inputs::File do
       sincedb_content = File.read(sincedb_path).strip
       expect( sincedb_content ).to_not be_empty
 
-      sleep(1.5) # > sincedb_clean_after
+      Stud.try(3.times) do
+        sleep(1.5) # > sincedb_clean_after
 
-      sincedb_content = File.read(sincedb_path).strip
-      expect( sincedb_content ).to be_empty
+        sincedb_content = File.read(sincedb_path).strip
+        expect( sincedb_content ).to be_empty
+      end
     end
 
   end


### PR DESCRIPTION
In certain cases, in read mode such as the one described in https://github.com/logstash-plugins/logstash-input-file/issues/250 sincedb is not updated. 

There was no periodic check for sincedb updates that would cause the `sincedb_clean_after` entries to cleanup.
The cleanup relied on new files being discovered or new content being added to existing files -> causing sincedb updates.

The fix here is to periodically flush sincedb (from the watch loop).
Besides, to make the process more deterministic, there's a minor change to make sure the same "updated" timestamp is used to mark the last changed time.

resolves https://github.com/logstash-plugins/logstash-input-file/issues/250
expected to also resolve https://github.com/logstash-plugins/logstash-input-file/issues/260