### PR TITLE
Refactor: improve debug logging (log catched exceptions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.3
+  - Refactor: improve debug logging (log catched exceptions) [#280](https://github.com/logstash-plugins/logstash-input-file/pull/280)
+
 ## 4.2.2
   - Fix: sincedb_clean_after not being respected [#276](https://github.com/logstash-plugins/logstash-input-file/pull/276)
 

--- a/lib/filewatch/read_mode/handlers/base.rb
+++ b/lib/filewatch/read_mode/handlers/base.rb
@@ -19,7 +19,7 @@ module FileWatch module ReadMode module Handlers
     end
 
     def handle(watched_file)
-      logger.trace("handling: #{watched_file.path}")
+      logger.trace? && logger.trace("handling:", :path => watched_file.path)
       unless watched_file.has_listener?
         watched_file.set_listener(@observer)
       end

--- a/lib/filewatch/read_mode/handlers/base.rb
+++ b/lib/filewatch/read_mode/handlers/base.rb
@@ -41,14 +41,14 @@ module FileWatch module ReadMode module Handlers
         # don't emit this message too often. if a file that we can't
         # read is changing a lot, we'll try to open it more often, and spam the logs.
         now = Time.now.to_i
-        logger.trace("opening OPEN_WARN_INTERVAL is '#{OPEN_WARN_INTERVAL}'")
+        logger.trace? && logger.trace("opening OPEN_WARN_INTERVAL is '#{OPEN_WARN_INTERVAL}'")
         if watched_file.last_open_warning_at.nil? || now - watched_file.last_open_warning_at > OPEN_WARN_INTERVAL
           backtrace = e.backtrace
           backtrace = backtrace.take(3) if backtrace && !logger.debug?
           logger.warn("failed to open", :path => watched_file.path, :exception => e.class, :message => e.message, :backtrace => backtrace)
           watched_file.last_open_warning_at = now
         else
-          logger.trace("suppressed warning (failed to open)", :path => watched_file.path, :exception => e.class, :message => e.message)
+          logger.trace? && logger.trace("suppressed warning (failed to open)", :path => watched_file.path, :exception => e.class, :message => e.message)
         end
         watched_file.watch # set it back to watch so we can try it again
       end
@@ -67,8 +67,7 @@ module FileWatch module ReadMode module Handlers
       elsif sincedb_value.watched_file == watched_file
         update_existing_sincedb_collection_value(watched_file, sincedb_value)
       else
-        msg = "add_or_update_sincedb_collection: the found sincedb_value has a watched_file - this is a rename, switching inode to this watched file"
-        logger.trace(msg)
+        logger.trace? && logger.trace("add_or_update_sincedb_collection: the found sincedb_value has a watched_file - this is a rename, switching inode to this watched file")
         existing_watched_file = sincedb_value.watched_file
         if existing_watched_file.nil?
           sincedb_value.set_watched_file(watched_file)
@@ -77,7 +76,7 @@ module FileWatch module ReadMode module Handlers
           watched_file.update_bytes_read(sincedb_value.position)
         else
           sincedb_value.set_watched_file(watched_file)
-          logger.trace("add_or_update_sincedb_collection: switching from", :watched_file => watched_file.details)
+          logger.trace? && logger.trace("add_or_update_sincedb_collection: switching from", :watched_file => watched_file.details)
           watched_file.rotate_from(existing_watched_file)
         end
 
@@ -86,7 +85,7 @@ module FileWatch module ReadMode module Handlers
     end
 
     def update_existing_sincedb_collection_value(watched_file, sincedb_value)
-      logger.trace("update_existing_sincedb_collection_value: #{watched_file.path}, last value #{sincedb_value.position}, cur size #{watched_file.last_stat_size}")
+      logger.trace? && logger.trace("update_existing_sincedb_collection_value: #{watched_file.path}, last value #{sincedb_value.position}, cur size #{watched_file.last_stat_size}")
       # sincedb_value is the source of truth
       watched_file.update_bytes_read(sincedb_value.position)
     end
@@ -94,7 +93,7 @@ module FileWatch module ReadMode module Handlers
     def add_new_value_sincedb_collection(watched_file)
       sincedb_value = SincedbValue.new(0)
       sincedb_value.set_watched_file(watched_file)
-      logger.trace("add_new_value_sincedb_collection:", :path => watched_file.path, :position => sincedb_value.position)
+      logger.trace? && logger.trace("add_new_value_sincedb_collection:", :path => watched_file.path, :position => sincedb_value.position)
       sincedb_collection.set(watched_file.sincedb_key, sincedb_value)
     end
   end

--- a/lib/filewatch/sincedb_record_serializer.rb
+++ b/lib/filewatch/sincedb_record_serializer.rb
@@ -14,10 +14,6 @@ module FileWatch
       @expired_keys = []
     end
 
-    def update_sincedb_value_expiry_from_days(days)
-      @sincedb_value_expiry = SincedbRecordSerializer.days_to_seconds(days)
-    end
-
     def serialize(db, io, as_of = Time.now.to_f)
       @expired_keys.clear
       db.each do |key, value|
@@ -36,8 +32,7 @@ module FileWatch
     end
 
     def serialize_record(k, v)
-      # effectively InodeStruct#to_s SincedbValue#to_s
-      "#{k} #{v}\n"
+      "#{k} #{v}\n" # effectively InodeStruct#to_s SincedbValue#to_s
     end
 
     def deserialize_record(record)

--- a/lib/filewatch/sincedb_record_serializer.rb
+++ b/lib/filewatch/sincedb_record_serializer.rb
@@ -3,26 +3,25 @@
 module FileWatch
   class SincedbRecordSerializer
 
-    attr_reader :expired_keys
-
     def self.days_to_seconds(days)
       (24 * 3600) * days.to_f
     end
 
     def initialize(sincedb_value_expiry)
       @sincedb_value_expiry = sincedb_value_expiry
-      @expired_keys = []
     end
 
+    # @return Array expired keys (ones that were not written to the file)
     def serialize(db, io, as_of = Time.now.to_f)
-      @expired_keys.clear
+      expired_keys = []
       db.each do |key, value|
         if as_of > value.last_changed_at_expires(@sincedb_value_expiry)
-          @expired_keys << key
+          expired_keys << key
           next
         end
         io.write(serialize_record(key, value))
       end
+      expired_keys
     end
 
     def deserialize(io)

--- a/lib/filewatch/tail_mode/handlers/base.rb
+++ b/lib/filewatch/tail_mode/handlers/base.rb
@@ -18,7 +18,7 @@ module FileWatch module TailMode module Handlers
     end
 
     def handle(watched_file)
-      logger.trace("handling: #{watched_file.filename}")
+      logger.trace? && logger.trace("handling:", :path => watched_file.path)
       unless watched_file.has_listener?
         watched_file.set_listener(@observer)
       end
@@ -37,7 +37,7 @@ module FileWatch module TailMode module Handlers
 
     def controlled_read(watched_file, loop_control)
       changed = false
-      logger.trace("reading...", "iterations" => loop_control.count, "amount" => loop_control.size, "filename" => watched_file.filename)
+      logger.trace(__method__.to_s, :iterations => loop_control.count, :amount => loop_control.size, :filename => watched_file.filename)
       # from a real config (has 102 file inputs)
       # -- This cfg creates a file input for every log file to create a dedicated file pointer and read all file simultaneously
       # -- If we put all log files in one file input glob we will have indexing delay, because Logstash waits until the first file becomes EOF
@@ -48,7 +48,7 @@ module FileWatch module TailMode module Handlers
       loop_control.count.times do
         break if quit?
         begin
-          logger.debug("read_to_eof: get chunk")
+          logger.debug("#{__method__} get chunk")
           result = watched_file.read_extract_lines(loop_control.size) # expect BufferExtractResult
           logger.trace(result.warning, result.additional) unless result.warning.empty?
           changed = true
@@ -59,38 +59,40 @@ module FileWatch module TailMode module Handlers
           end
         rescue EOFError
           # it only makes sense to signal EOF in "read" mode not "tail"
+          logger.debug("#{__method__} EOF", :path => watched_file.path)
           loop_control.flag_read_error
           break
-        rescue Errno::EWOULDBLOCK, Errno::EINTR
+        rescue Errno::EWOULDBLOCK, Errno::EINTR => e
+          logger.debug("#{__method__} #{e.inspect}", :path => watched_file.path)
           watched_file.listener.error
           loop_control.flag_read_error
           break
         rescue => e
-          logger.error("read_to_eof: general error reading #{watched_file.path}", "error" => e.inspect, "backtrace" => e.backtrace.take(4))
+          logger.error("#{__method__} general error reading", exception_details(watched_file.path, e))
           watched_file.listener.error
           loop_control.flag_read_error
           break
         end
       end
-      logger.debug("read_to_eof: exit due to quit") if quit?
+      logger.debug("#{__method__} stopped loop due quit") if quit?
       sincedb_collection.request_disk_flush if changed
     end
 
     def open_file(watched_file)
       return true if watched_file.file_open?
-      logger.trace("opening #{watched_file.filename}")
+      logger.trace? && logger.trace("open_file", :filename => watched_file.filename)
       begin
         watched_file.open
-      rescue
+      rescue => e
         # don't emit this message too often. if a file that we can't
         # read is changing a lot, we'll try to open it more often, and spam the logs.
         now = Time.now.to_i
-        logger.trace("open_file OPEN_WARN_INTERVAL is '#{OPEN_WARN_INTERVAL}'")
+        logger.trace? && logger.trace("open_file OPEN_WARN_INTERVAL is '#{OPEN_WARN_INTERVAL}'")
         if watched_file.last_open_warning_at.nil? || now - watched_file.last_open_warning_at > OPEN_WARN_INTERVAL
-          logger.warn("failed to open #{watched_file.path}: #{$!.inspect}, #{$!.backtrace.take(3)}")
+          logger.warn("failed to open file", exception_details(watched_file.path, e))
           watched_file.last_open_warning_at = now
         else
-          logger.trace("suppressed warning for `failed to open` #{watched_file.path}: #{$!.inspect}")
+          logger.debug("open_file suppressed warning `failed to open file`", exception_details(watched_file.path, e, false))
         end
         watched_file.watch # set it back to watch so we can try it again
       else
@@ -108,17 +110,13 @@ module FileWatch module TailMode module Handlers
         update_existing_sincedb_collection_value(watched_file, sincedb_value)
         watched_file.initial_completed
       else
-        msg = "add_or_update_sincedb_collection: found sincedb record"
-        logger.trace(msg,
-          "sincedb key" => watched_file.sincedb_key,
-          "sincedb value" => sincedb_value
-        )
+        logger.trace("add_or_update_sincedb_collection: found sincedb record",
+                     :sincedb_key => watched_file.sincedb_key, :sincedb_value => sincedb_value)
         # detected a rotation, Discoverer can't handle this because this watched file is not a new discovery.
         # we must handle it here, by transferring state and have the sincedb value track this watched file
         # rotate_as_file and rotate_from will switch the sincedb key to the inode that the path is now pointing to
         # and pickup the sincedb_value from before.
-        msg = "add_or_update_sincedb_collection: the found sincedb_value has a watched_file - this is a rename, switching inode to this watched file"
-        logger.trace(msg)
+        logger.debug("add_or_update_sincedb_collection: the found sincedb_value has a watched_file - this is a rename, switching inode to this watched file")
         existing_watched_file = sincedb_value.watched_file
         if existing_watched_file.nil?
           sincedb_value.set_watched_file(watched_file)
@@ -127,7 +125,7 @@ module FileWatch module TailMode module Handlers
           watched_file.update_bytes_read(sincedb_value.position)
         else
           sincedb_value.set_watched_file(watched_file)
-          logger.trace("add_or_update_sincedb_collection: switching from...", "watched_file details" => watched_file.details)
+          logger.trace("add_or_update_sincedb_collection: switching from:", :watched_file => watched_file.details)
           watched_file.rotate_from(existing_watched_file)
         end
       end
@@ -135,13 +133,14 @@ module FileWatch module TailMode module Handlers
     end
 
     def update_existing_sincedb_collection_value(watched_file, sincedb_value)
-      logger.trace("update_existing_sincedb_collection_value: #{watched_file.filename}, last value #{sincedb_value.position}, cur size #{watched_file.last_stat_size}")
+      logger.trace("update_existing_sincedb_collection_value", :position => sincedb_value.position,
+                   :filename => watched_file.filename, :last_stat_size => watched_file.last_stat_size)
       update_existing_specifically(watched_file, sincedb_value)
     end
 
     def add_new_value_sincedb_collection(watched_file)
       sincedb_value = get_new_value_specifically(watched_file)
-      logger.trace("add_new_value_sincedb_collection", "position" => sincedb_value.position, "watched_file details" => watched_file.details)
+      logger.trace("add_new_value_sincedb_collection", :position => sincedb_value.position, :watched_file => watched_file.details)
       sincedb_collection.set(watched_file.sincedb_key, sincedb_value)
       sincedb_value
     end
@@ -153,5 +152,14 @@ module FileWatch module TailMode module Handlers
       watched_file.update_bytes_read(position)
       value
     end
+
+    private
+
+    def exception_details(path, e, trace = true)
+      details = { :path => path, :exception => e.class, :message => e.message }
+      details[:backtrace] = e.backtrace if trace && logger.debug?
+      details
+    end
+
   end
 end end end

--- a/lib/filewatch/tail_mode/handlers/base.rb
+++ b/lib/filewatch/tail_mode/handlers/base.rb
@@ -37,7 +37,7 @@ module FileWatch module TailMode module Handlers
 
     def controlled_read(watched_file, loop_control)
       changed = false
-      logger.trace(__method__.to_s, :iterations => loop_control.count, :amount => loop_control.size, :filename => watched_file.filename)
+      logger.trace? && logger.trace(__method__.to_s, :iterations => loop_control.count, :amount => loop_control.size, :filename => watched_file.filename)
       # from a real config (has 102 file inputs)
       # -- This cfg creates a file input for every log file to create a dedicated file pointer and read all file simultaneously
       # -- If we put all log files in one file input glob we will have indexing delay, because Logstash waits until the first file becomes EOF
@@ -48,7 +48,7 @@ module FileWatch module TailMode module Handlers
       loop_control.count.times do
         break if quit?
         begin
-          logger.debug("#{__method__} get chunk")
+          logger.debug? && logger.debug("#{__method__} get chunk")
           result = watched_file.read_extract_lines(loop_control.size) # expect BufferExtractResult
           logger.trace(result.warning, result.additional) unless result.warning.empty?
           changed = true
@@ -110,8 +110,8 @@ module FileWatch module TailMode module Handlers
         update_existing_sincedb_collection_value(watched_file, sincedb_value)
         watched_file.initial_completed
       else
-        logger.trace("add_or_update_sincedb_collection: found sincedb record",
-                     :sincedb_key => watched_file.sincedb_key, :sincedb_value => sincedb_value)
+        logger.trace? && logger.trace("add_or_update_sincedb_collection: found sincedb record",
+                                      :sincedb_key => watched_file.sincedb_key, :sincedb_value => sincedb_value)
         # detected a rotation, Discoverer can't handle this because this watched file is not a new discovery.
         # we must handle it here, by transferring state and have the sincedb value track this watched file
         # rotate_as_file and rotate_from will switch the sincedb key to the inode that the path is now pointing to
@@ -120,12 +120,12 @@ module FileWatch module TailMode module Handlers
         existing_watched_file = sincedb_value.watched_file
         if existing_watched_file.nil?
           sincedb_value.set_watched_file(watched_file)
-          logger.trace("add_or_update_sincedb_collection: switching as new file")
+          logger.trace? && logger.trace("add_or_update_sincedb_collection: switching as new file")
           watched_file.rotate_as_file
           watched_file.update_bytes_read(sincedb_value.position)
         else
           sincedb_value.set_watched_file(watched_file)
-          logger.trace("add_or_update_sincedb_collection: switching from:", :watched_file => watched_file.details)
+          logger.trace? && logger.trace("add_or_update_sincedb_collection: switching from:", :watched_file => watched_file.details)
           watched_file.rotate_from(existing_watched_file)
         end
       end
@@ -133,14 +133,15 @@ module FileWatch module TailMode module Handlers
     end
 
     def update_existing_sincedb_collection_value(watched_file, sincedb_value)
-      logger.trace("update_existing_sincedb_collection_value", :position => sincedb_value.position,
-                   :filename => watched_file.filename, :last_stat_size => watched_file.last_stat_size)
+      logger.trace? && logger.trace("update_existing_sincedb_collection_value", :position => sincedb_value.position,
+                                    :filename => watched_file.filename, :last_stat_size => watched_file.last_stat_size)
       update_existing_specifically(watched_file, sincedb_value)
     end
 
     def add_new_value_sincedb_collection(watched_file)
       sincedb_value = get_new_value_specifically(watched_file)
-      logger.trace("add_new_value_sincedb_collection", :position => sincedb_value.position, :watched_file => watched_file.details)
+      logger.trace? && logger.trace("add_new_value_sincedb_collection", :position => sincedb_value.position,
+                                    :watched_file => watched_file.details)
       sincedb_collection.set(watched_file.sincedb_key, sincedb_value)
       sincedb_value
     end

--- a/lib/filewatch/tail_mode/handlers/base.rb
+++ b/lib/filewatch/tail_mode/handlers/base.rb
@@ -57,13 +57,13 @@ module FileWatch module TailMode module Handlers
             # sincedb position is now independent from the watched_file bytes_read
             sincedb_collection.increment(watched_file.sincedb_key, line.bytesize + @settings.delimiter_byte_size)
           end
-        rescue EOFError
+        rescue EOFError => e
           # it only makes sense to signal EOF in "read" mode not "tail"
-          logger.debug("#{__method__} EOF", :path => watched_file.path)
+          logger.debug(__method__.to_s, exception_details(watched_file.path, e, false))
           loop_control.flag_read_error
           break
         rescue Errno::EWOULDBLOCK, Errno::EINTR => e
-          logger.debug("#{__method__} #{e.inspect}", :path => watched_file.path)
+          logger.debug(__method__.to_s, exception_details(watched_file.path, e, false))
           watched_file.listener.error
           loop_control.flag_read_error
           break

--- a/lib/filewatch/tail_mode/handlers/delete.rb
+++ b/lib/filewatch/tail_mode/handlers/delete.rb
@@ -7,7 +7,7 @@ module FileWatch module TailMode module Handlers
       # TODO consider trying to find the renamed file - it will have the same inode.
       # Needs a rotate scheme rename hint from user e.g. "<name>-YYYY-MM-DD-N.<ext>" or "<name>.<ext>.N"
       # send the found content to the same listener (stream identity)
-      logger.trace(__method__.to_s, :path => watched_file.path, :watched_file => watched_file.details)
+      logger.trace? && logger.trace(__method__.to_s, :path => watched_file.path, :watched_file => watched_file.details)
       if watched_file.bytes_unread > 0
         logger.warn(DATA_LOSS_WARNING, :path => watched_file.path, :unread_bytes => watched_file.bytes_unread)
       end

--- a/lib/filewatch/tail_mode/handlers/delete.rb
+++ b/lib/filewatch/tail_mode/handlers/delete.rb
@@ -7,7 +7,7 @@ module FileWatch module TailMode module Handlers
       # TODO consider trying to find the renamed file - it will have the same inode.
       # Needs a rotate scheme rename hint from user e.g. "<name>-YYYY-MM-DD-N.<ext>" or "<name>.<ext>.N"
       # send the found content to the same listener (stream identity)
-      logger.trace("delete", :path => watched_file.path, :watched_file => watched_file.details)
+      logger.trace(__method__.to_s, :path => watched_file.path, :watched_file => watched_file.details)
       if watched_file.bytes_unread > 0
         logger.warn(DATA_LOSS_WARNING, :path => watched_file.path, :unread_bytes => watched_file.bytes_unread)
       end

--- a/lib/filewatch/tail_mode/handlers/shrink.rb
+++ b/lib/filewatch/tail_mode/handlers/shrink.rb
@@ -14,11 +14,10 @@ module FileWatch module TailMode module Handlers
     end
 
     def update_existing_specifically(watched_file, sincedb_value)
-      # we have a match but size is smaller
-      # set all to zero
+      # we have a match but size is smaller - set all to zero
       watched_file.reset_bytes_unread
       sincedb_value.update_position(0)
-      logger.trace("update_existing_specifically: was truncated seeking to beginning", "watched file" => watched_file.details, "sincedb value" => sincedb_value)
+      logger.trace("update_existing_specifically: was truncated seeking to beginning", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
     end
   end
 end end end

--- a/lib/filewatch/tail_mode/handlers/shrink.rb
+++ b/lib/filewatch/tail_mode/handlers/shrink.rb
@@ -17,7 +17,7 @@ module FileWatch module TailMode module Handlers
       # we have a match but size is smaller - set all to zero
       watched_file.reset_bytes_unread
       sincedb_value.update_position(0)
-      logger.trace("update_existing_specifically: was truncated seeking to beginning", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
+      logger.trace? && logger.trace("update_existing_specifically: was truncated seeking to beginning", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
     end
   end
 end end end

--- a/lib/filewatch/tail_mode/handlers/unignore.rb
+++ b/lib/filewatch/tail_mode/handlers/unignore.rb
@@ -13,9 +13,9 @@ module FileWatch module TailMode module Handlers
       # for file initially ignored their bytes_read was set to stat.size
       # use this value not the `start_new_files_at` for the position
       # logger.trace("get_new_value_specifically", "watched_file" => watched_file.inspect)
-      SincedbValue.new(watched_file.bytes_read).tap do |val|
-        val.set_watched_file(watched_file)
-        logger.trace("-------------------- >>>>> get_new_value_specifically: unignore", "watched file" => watched_file.details, "sincedb value" => val)
+      SincedbValue.new(watched_file.bytes_read).tap do |sincedb_value|
+        sincedb_value.set_watched_file(watched_file)
+        logger.trace("get_new_value_specifically: unignore", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
       end
     end
 
@@ -26,7 +26,7 @@ module FileWatch module TailMode module Handlers
       # we will handle grow or shrink
       # for now we seek to where we were before the file got ignored (grow)
       # or to the start (shrink)
-      logger.trace("-------------------- >>>>> update_existing_specifically: unignore", "watched file" => watched_file.details, "sincedb value" => sincedb_value)
+      logger.trace("update_existing_specifically: unignore", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
       position = 0
       if watched_file.shrunk?
         watched_file.update_bytes_read(0)

--- a/lib/filewatch/tail_mode/handlers/unignore.rb
+++ b/lib/filewatch/tail_mode/handlers/unignore.rb
@@ -15,7 +15,7 @@ module FileWatch module TailMode module Handlers
       # logger.trace("get_new_value_specifically", "watched_file" => watched_file.inspect)
       SincedbValue.new(watched_file.bytes_read).tap do |sincedb_value|
         sincedb_value.set_watched_file(watched_file)
-        logger.trace("get_new_value_specifically: unignore", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
+        logger.trace? && logger.trace("get_new_value_specifically: unignore", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
       end
     end
 
@@ -26,7 +26,7 @@ module FileWatch module TailMode module Handlers
       # we will handle grow or shrink
       # for now we seek to where we were before the file got ignored (grow)
       # or to the start (shrink)
-      logger.trace("update_existing_specifically: unignore", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
+      logger.trace? && logger.trace("update_existing_specifically: unignore", :watched_file => watched_file.details, :sincedb_value => sincedb_value)
       position = 0
       if watched_file.shrunk?
         watched_file.update_bytes_read(0)

--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -377,6 +377,7 @@ class File < LogStash::Inputs::Base
   def handle_deletable_path(path)
     return if tail_mode?
     return if @completed_file_handlers.empty?
+    @logger.debug(__method__.to_s, :path => path)
     @completed_file_handlers.each { |handler| handler.handle(path) }
   end
 

--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -377,13 +377,12 @@ class File < LogStash::Inputs::Base
   def handle_deletable_path(path)
     return if tail_mode?
     return if @completed_file_handlers.empty?
-    @logger.debug(__method__.to_s, :path => path)
+    @logger.debug? && @logger.debug(__method__.to_s, :path => path)
     @completed_file_handlers.each { |handler| handler.handle(path) }
   end
 
   def log_line_received(path, line)
-    return unless @logger.debug?
-    @logger.debug("Received line", :path => path, :text => line)
+    @logger.debug? && @logger.debug("Received line", :path => path, :text => line)
   end
 
   def stop

--- a/lib/logstash/inputs/file_listener.rb
+++ b/lib/logstash/inputs/file_listener.rb
@@ -7,9 +7,9 @@ module LogStash module Inputs
   class FileListener
     attr_reader :input, :path, :data
     # construct with link back to the input plugin instance.
-    def initialize(path, input)
+    def initialize(path, input, data = nil)
       @path, @input = path, input
-      @data = nil
+      @data = data
     end
 
     def opened
@@ -36,7 +36,7 @@ module LogStash module Inputs
     def accept(data)
       # and push transient data filled dup listener downstream
       input.log_line_received(path, data)
-      input.codec.accept(dup_adding_state(data))
+      input.codec.accept(self.class.new(path, input, data))
     end
 
     def process_event(event)
@@ -45,17 +45,6 @@ module LogStash module Inputs
       input.post_process_this(event)
     end
 
-    def add_state(data)
-      @data = data
-      self
-    end
-
-    private
-
-    # duplicate and add state for downstream
-    def dup_adding_state(line)
-      self.class.new(path, input).add_state(line)
-    end
   end
 
   class FlushableListener < FileListener

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.2.2'
+  s.version         = '4.2.3'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filewatch/sincedb_record_serializer_spec.rb
+++ b/spec/filewatch/sincedb_record_serializer_spec.rb
@@ -9,7 +9,9 @@ module FileWatch
     let(:io) { StringIO.new }
     let(:db) { Hash.new }
 
-    subject { SincedbRecordSerializer.new(SincedbRecordSerializer.days_to_seconds(14)) }
+    let(:sincedb_value_expiry) { SincedbRecordSerializer.days_to_seconds(14) }
+
+    subject { SincedbRecordSerializer.new(sincedb_value_expiry) }
 
     context "deserialize from IO" do
       it 'reads V1 records' do
@@ -82,8 +84,10 @@ module FileWatch
     end
 
     context "given a non default `sincedb_clean_after`" do
+
+      let(:sincedb_value_expiry) { SincedbRecordSerializer.days_to_seconds(2) }
+
       it "does not write expired db entries to an IO object" do
-        subject.update_sincedb_value_expiry_from_days(2)
         one_day_ago = Time.now.to_f - (1.0*24*3600)
         three_days_ago = one_day_ago - (2.0*24*3600)
         db[InodeStruct.new("42424242", 2, 5)] = SincedbValue.new(42, one_day_ago)


### PR DESCRIPTION
tried to normalize traces involving `:filename` or `:path` to be more consistent - easier to grep.
otherwise the intent is mostly (debug) logging exceptions the plugin's expected to rescue and continue running. 

particularly, I wasn't sure why a watched file keeps going through the read loop (having new content)
but comes out as never reading anything on Windows (e.g. [from here](https://github.com/logstash-plugins/logstash-input-file/compare/master...kares:better-logs#diff-c57c0035b677d378b5582636b6f26aeb8c39f459b98954965978c10391d47951R66)), knowing whether there's an EOF or file-access gone wrong would confirm whether there's a deeper issue in the plugin or not.

have also raised a few traces to the debug level - ones that seem to provide more value than just tracing what the plugin is processing atm.