### PR TITLE
Fix: sincedb_write issue on Windows machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.4
+  - Fix: sincedb_write issue on Windows machines [#283](https://github.com/logstash-plugins/logstash-input-file/pull/283)
+
 ## 4.2.3
   - Refactor: improve debug logging (log catched exceptions) [#280](https://github.com/logstash-plugins/logstash-input-file/pull/280)
 

--- a/lib/filewatch/sincedb_collection.rb
+++ b/lib/filewatch/sincedb_collection.rb
@@ -232,7 +232,7 @@ module FileWatch
 
     # @return expired keys
     def non_atomic_write(time)
-      IO.open(IO.sysopen(@full_path, "w+")) do |io|
+      File.open(@full_path, "w+") do |io|
         @serializer.serialize(@sincedb, io, time.to_f)
       end
     end

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.2.3'
+  s.version         = '4.2.4'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
On our Windows servers we for some reason, occasionally, get exceptions with classes IOError and Java::JavaLang:RuntimeException when writing to sincedb file which crashes the plugin and somehow messes with the sincedb file which results in old log files being reprocessed causing duplicates. If we rescue the errors then everything is fine which is the reason for this change.

This is an example of the IOError we get:
```
[2021-03-10T20:34:56,562][ERROR][logstash.javapipeline    ][main][application-customer-input] A plugin had an unrecoverable error. Will restart this plugin.
  Pipeline_id:main
  Plugin: <LogStash::Inputs::File start_position=>"beginning", path=>["D:/Logs/customer/*.txt"], codec=><LogStash::Codecs::Multiline pattern=>"^%{TIMESTAMP_ISO8601:timestamp}", what=>"previous", id=>"7933efd1-d366-43f1-9669-c388b304d745", negate=>true, enable_metric=>true, charset=>"UTF-8", multiline_tag=>"multiline", max_lines=>500, max_bytes=>10485760>, sincedb_clean_after=>1209600.0, ignore_older=>1123200.0, id=>"application-customer-input", type=>"application-customer", enable_metric=>true, stat_interval=>1.0, discover_interval=>15, sincedb_write_interval=>15.0, delimiter=>"\n", close_older=>3600.0, mode=>"tail", file_completed_action=>"delete", file_chunk_size=>32768, file_chunk_count=>140737488355327, file_sort_by=>"last_modified", file_sort_direction=>"asc", exit_after_read=>false, check_archive_validity=>false>
  Error: The handle is invalid
  Exception: IOError
  Stack: org/jruby/RubyIO.java:1234:in `sysopen'
org/jruby/RubyIO.java:1214:in `sysopen'
C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/sincedb_collection.rb:235:in `non_atomic_write'
org/jruby/RubyMethod.java:119:in `call'
C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/sincedb_collection.rb:212:in `sincedb_write'
C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/sincedb_collection.rb:185:in `flush_at_interval'
C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/watch.rb:57:in `subscribe'
C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/observing_tail.rb:12:in `subscribe'
C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/logstash/inputs/file.rb:364:in `run'
C:/logstash-7.11.1/logstash-core/lib/logstash/java_pipeline.rb:405:in `inputworker'
C:/logstash-7.11.1/logstash-core/lib/logstash/java_pipeline.rb:396:in `block in start_input'
[2021-03-10T20:34:57,683][INFO ][filewatch.observingtail  ][main][application-customer-input] QUIT - closing all files and shutting down.
```

This is an example of the Java::JavaLang:RuntimeException we get:
```
[2021-03-12T02:06:43,247][ERROR][logstash.javapipeline    ][main][application-product-api-input] A plugin had an unrecoverable error. Will restart this plugin.
  Pipeline_id:main
  Plugin: <LogStash::Inputs::File start_position=>"beginning", path=>["D:/Logs/productapi/*.txt"], codec=><LogStash::Codecs::Multiline pattern=>"^%{TIMESTAMP_ISO8601:timestamp}", what=>"previous", id=>"91a3327c-f546-4b06-a0a6-63cd41dd4ac9", negate=>true, enable_metric=>true, charset=>"UTF-8", multiline_tag=>"multiline", max_lines=>500, max_bytes=>10485760>, sincedb_clean_after=>1209600.0, ignore_older=>1123200.0, id=>"application-product-api-input", type=>"application-product-api", enable_metric=>true, stat_interval=>1.0, discover_interval=>15, sincedb_write_interval=>15.0, delimiter=>"\n", close_older=>3600.0, mode=>"tail", file_completed_action=>"delete", file_chunk_size=>32768, file_chunk_count=>140737488355327, file_sort_by=>"last_modified", file_sort_direction=>"asc", exit_after_read=>false, check_archive_validity=>false>
  Error: unknown IOException: java.io.IOException: The handle is invalid
  Exception: Java::JavaLang::RuntimeException
  Stack: org.jruby.util.io.PosixShim.close(PosixShim.java:259)
org.jruby.util.io.PosixShim.close(PosixShim.java:247)
org.jruby.util.io.OpenFile.finalizeFlush(OpenFile.java:899)
org.jruby.RubyIO.rbIoClose(RubyIO.java:2044)
org.jruby.RubyIO.close(RubyIO.java:1990)
org.jruby.RubyIO$INVOKER$i$0$0$close.call(RubyIO$INVOKER$i$0$0$close.gen)
org.jruby.RubyClass.checkFuncallDefault(RubyClass.java:659)
org.jruby.RubyClass.finvokeChecked(RubyClass.java:603)
org.jruby.runtime.Helpers.invokeChecked(Helpers.java:501)
org.jruby.RubyBasicObject.checkCallMethod(RubyBasicObject.java:346)
org.jruby.RubyIO.ioClose(RubyIO.java:2003)
org.jruby.RubyIO.ensureYieldClose(RubyIO.java:1166)
org.jruby.RubyIO.open(RubyIO.java:1158)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.filewatch.sincedb_collection.RUBY$method$non_atomic_write$0(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/sincedb_collection.rb:235)
org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:106)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:140)
org.jruby.RubyMethod.call(RubyMethod.java:119)
org.jruby.RubyMethod$INVOKER$i$call.call(RubyMethod$INVOKER$i$call.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroOrOneOrNBlock.call(JavaMethod.java:349)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.filewatch.sincedb_collection.RUBY$method$sincedb_write$0(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/sincedb_collection.rb:212)
org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:80)
org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:103)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:140)
org.jruby.ir.targets.InvokeSite.fail(InvokeSite.java:278)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.filewatch.sincedb_collection.RUBY$method$flush_at_interval$0(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/sincedb_collection.rb:185)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.filewatch.sincedb_collection.RUBY$method$flush_at_interval$0$__VARARGS__(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/sincedb_collection.rb)
org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:80)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:70)
org.jruby.ir.targets.InvokeSite.fail(InvokeSite.java:248)
org.jruby.ir.targets.InvokeSite.fail(InvokeSite.java:255)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.filewatch.watch.RUBY$method$subscribe$0(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/watch.rb:57)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.filewatch.watch.RUBY$method$subscribe$0$__VARARGS__(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/watch.rb)
org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:80)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:70)
org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:207)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.filewatch.observing_tail.RUBY$method$subscribe$0(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/observing_tail.rb:12)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.filewatch.observing_tail.RUBY$method$subscribe$0$__VARARGS__(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/filewatch/observing_tail.rb)
org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:80)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:70)
org.jruby.ir.targets.InvokeSite.invoke(InvokeSite.java:207)
C_3a_.logstash_minus_7_dot_11_dot_1.vendor.bundle.jruby.$2_dot_5_dot_0.gems.logstash_minus_input_minus_file_minus_4_dot_2_dot_3.lib.logstash.inputs.file.RUBY$method$run$0(C:/logstash-7.11.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-file-4.2.3/lib/logstash/inputs/file.rb:364)
org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:106)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:140)
org.jruby.ir.targets.InvokeSite.fail(InvokeSite.java:278)
C_3a_.logstash_minus_7_dot_11_dot_1.logstash_minus_core.lib.logstash.java_pipeline.RUBY$method$inputworker$0(C:/logstash-7.11.1/logstash-core/lib/logstash/java_pipeline.rb:405)
C_3a_.logstash_minus_7_dot_11_dot_1.logstash_minus_core.lib.logstash.java_pipeline.RUBY$block$start_input$1(C:/logstash-7.11.1/logstash-core/lib/logstash/java_pipeline.rb:396)
org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:138)
org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:58)
org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:52)
org.jruby.runtime.Block.call(Block.java:139)
org.jruby.RubyProc.call(RubyProc.java:318)
org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:105)
java.base/java.lang.Thread.run(Thread.java:834)
[2021-03-12T02:06:44,304][INFO ][filewatch.observingtail  ][main][application-product-api-input] QUIT - closing all files and shutting down.
[2021-03-12T02:06:44,314][INFO ][filewatch.observingtail  ][main][application-product-api-input] START, creating Discoverer, Watch with file and sincedb collections
```

With the change we get:
```
[2021-03-15T10:25:47,278][WARN ][filewatch.sincedbcollection][main][application-pharmacy-api-input] sincedb_write: C:/logstash-7.11.1/data/plugins/inputs/file/.sincedb_334238b39b987e24f81f35882286bcf3 error: {:exception=>IOError, :message=>"The handle is invalid"}
```
and
```
[2021-03-15T16:49:05,736][WARN ][filewatch.sincedbcollection][main][application-prescription-api-input] sincedb_write: C:/logstash-7.11.1/data/plugins/inputs/file/.sincedb_d41d8cd98f00b204e9800998ecf8427e error: {:exception=>Java::JavaLang::RuntimeException, :message=>"unknown IOException: java.io.IOException: The handle is invalid"}
```