### PR TITLE
Mark fully read zip file completed in sincedb

### DIFF
--- a/lib/filewatch/read_mode/handlers/read_zip_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_zip_file.rb
@@ -55,6 +55,7 @@ module FileWatch module ReadMode module Handlers
           close_and_ignore_ioexception(file_stream) unless file_stream.nil?
         end
       end
+      sincedb_collection.reading_completed(key)
       sincedb_collection.clear_watched_file(key)
     end
 


### PR DESCRIPTION
This PR fixes #286

Note that this PR is currently missing a unit test for this as I am not really sure how to write one as I am not a ruby developer.
I think checking the @path_in_sincedb value after a complete read should be work as a unit test.
