### PR TITLE
Add ECS Compatibility mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.0
+  - Add ECS Compatibility Mode [#259](https://github.com/logstash-plugins/logstash-input-file/issues/259)
+
 ## 4.2.4
   - Fix: sincedb_write issue on Windows machines [#283](https://github.com/logstash-plugins/logstash-input-file/pull/283)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.3.0
-  - Add ECS Compatibility Mode [#259](https://github.com/logstash-plugins/logstash-input-file/issues/259)
+  - Add ECS Compatibility Mode [#291](https://github.com/logstash-plugins/logstash-input-file/pull/291)
 
 ## 4.2.4
   - Fix: sincedb_write issue on Windows machines [#283](https://github.com/logstash-plugins/logstash-input-file/pull/283)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -78,6 +78,7 @@ Read mode also allows for an action to take place after processing the file comp
 In the past attempts to simulate a Read mode while still assuming infinite streams
 was not ideal and a dedicated Read mode is an improvement.
 
+[id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 This plugin adds metadata about event's source, and can be configured to do so
@@ -269,8 +270,7 @@ In practice, this will be the best case because the time taken to read new conte
 ** Otherwise, the default value is `disabled`.
 
 Controls this plugin's compatibility with the
-{ecs-ref}[Elastic Common Schema (ECS)]
-(ECS)].
+{ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-exclude"]
 ===== `exclude`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -78,6 +78,20 @@ Read mode also allows for an action to take place after processing the file comp
 In the past attempts to simulate a Read mode while still assuming infinite streams
 was not ideal and a dedicated Read mode is an improvement.
 
+==== Compatibility with the Elastic Common Schema (ECS)
+
+This plugin adds metadata about event's source, and can be configured to do so
+in an {ecs-ref}[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
+This metadata is added after the event has been decoded by the appropriate codec,
+and will never overwrite existing values.
+
+|========
+| ECS Disabled | ECS v1 | Description
+
+| `host` | `[host][name]` | The name of the {ls} host that processed the event
+| `path` | `[log][file][path]` | The full path to the log file from which the event originates
+|========
+
 ==== Tracking of current position in watched files
 
 The plugin keeps track of the current position in each file by
@@ -168,6 +182,7 @@ see <<plugins-{type}s-{plugin}-string_duration,string_duration>> for the details
 | <<plugins-{type}s-{plugin}-close_older>> |<<number,number>> or <<plugins-{type}s-{plugin}-string_duration,string_duration>>|No
 | <<plugins-{type}s-{plugin}-delimiter>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-discover_interval>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-exclude>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-exit_after_read>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-file_chunk_count>> |<<number,number>>|No
@@ -241,6 +256,21 @@ How often we expand the filename patterns in the `path` option to discover new f
 This value is a multiple to `stat_interval`, e.g. if `stat_interval` is "500 ms" then new files
 files could be discovered every 15 X 500 milliseconds - 7.5 seconds.
 In practice, this will be the best case because the time taken to read new content needs to be factored in.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: sets non-ECS metadata on event (such as top-level `host`, `path`)
+** `v1`: sets ECS-compatible metadata on event (such as `[host][name]`, `[log][file][path]`)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the
+{ecs-ref}[Elastic Common Schema (ECS)]
+(ECS)].
 
 [id="plugins-{type}s-{plugin}-exclude"]
 ===== `exclude`

--- a/lib/logstash/inputs/file_listener.rb
+++ b/lib/logstash/inputs/file_listener.rb
@@ -41,7 +41,6 @@ module LogStash module Inputs
 
     def process_event(event)
       event.set("[@metadata][path]", path)
-      event.set("path", path) unless event.include?("path")
       input.post_process_this(event)
     end
 

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.2.4'
+  s.version         = '4.3.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-multiline', ['~> 3.0']
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.1'
 
   s.add_development_dependency 'stud', ['~> 0.0.19']
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Adds an ECS Compatibility mode.

Without this mode, metadata is persisted to each event's top-level `host` and `path` fields, but with ECS enabled, it is persisted to the ECS-compatible `[host][name]` and `[log][file][path]`.