### PR TITLE
Refactor: unify event updates to happen in one place

### DIFF
--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -373,12 +373,11 @@ class File < LogStash::Inputs::Base
     @completely_stopped.make_true
   end # def run
 
-  def post_process_this(event)
+  def post_process_this(event, path)
+    event.set("[@metadata][path]", path)
     event.set("[@metadata][host]", @host)
     attempt_set(event, @source_host_field, @host)
-
-    source_path = event.get('[@metadata][path]') and
-      attempt_set(event, @source_path_field, source_path)
+    attempt_set(event, @source_path_field, path) if path
 
     decorate(event)
     @queue.get << event

--- a/lib/logstash/inputs/file_listener.rb
+++ b/lib/logstash/inputs/file_listener.rb
@@ -40,8 +40,7 @@ module LogStash module Inputs
     end
 
     def process_event(event)
-      event.set("[@metadata][path]", path)
-      input.post_process_this(event)
+      input.post_process_this(event, path)
     end
 
   end

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -363,7 +363,9 @@ describe LogStash::Inputs::File do
     end
   end
 
-  def wait_for_file_removal(path, timeout: 3 * interval)
-    wait(timeout).for { File.exist?(path) }.to be_falsey
+  def wait_for_file_removal(path, timeout: interval)
+    try(5) do
+      wait(timeout).for { File.exist?(path) }.to be_falsey
+    end
   end
 end

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -338,7 +338,7 @@ describe LogStash::Inputs::File do
       sincedb_content = File.read(sincedb_path).strip
       expect( sincedb_content ).to_not be_empty
 
-      Stud.try(3.times) do
+      try(3) do
         sleep(1.5) # > sincedb_clean_after
 
         sincedb_content = File.read(sincedb_path).strip

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -363,7 +363,8 @@ describe LogStash::Inputs::File do
     end
   end
 
-  def wait_for_file_removal(path, timeout: interval)
+  def wait_for_file_removal(path)
+    timeout = interval
     try(5) do
       wait(timeout).for { File.exist?(path) }.to be_falsey
     end


### PR DESCRIPTION
This is a simple refactoring to have `event.set` in one place for easy understanding.

There's also 2 minor changes to make CI more stable - properly re-trying on rspec expectation failure