### PR TITLE
ecs: add v8 alias to v1 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.0
+  - Add support for ECS v8 [#301](https://github.com/logstash-plugins/logstash-input-file/pull/301)
+
 ## 4.3.1
   - Add extra safety to `chown` call in `atomic_write`, avoiding plugin crashes and falling back to a 
   `non_atomic_write` in the event of failure [#295](https://github.com/logstash-plugins/logstash-input-file/pull/295)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -87,7 +87,7 @@ This metadata is added after the event has been decoded by the appropriate codec
 and will never overwrite existing values.
 
 |========
-| ECS Disabled | ECS v1 | Description
+| ECS Disabled | ECS `v1`, `v8` | Description
 
 | `host` | `[host][name]` | The name of the {ls} host that processed the event
 | `path` | `[log][file][path]` | The full path to the log file from which the event originates
@@ -264,7 +264,7 @@ In practice, this will be the best case because the time taken to read new conte
 * Value type is <<string,string>>
 * Supported values are:
 ** `disabled`: sets non-ECS metadata on event (such as top-level `host`, `path`)
-** `v1`: sets ECS-compatible metadata on event (such as `[host][name]`, `[log][file][path]`)
+** `v1`,`v8`: sets ECS-compatible metadata on event (such as `[host][name]`, `[log][file][path]`)
 * Default value depends on which version of Logstash is running:
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.

--- a/lib/logstash/inputs/file.rb
+++ b/lib/logstash/inputs/file.rb
@@ -89,7 +89,7 @@ module LogStash module Inputs
 class File < LogStash::Inputs::Base
   config_name "file"
 
-  include PluginMixins::ECSCompatibilitySupport(:disabled, :v1)
+  include PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
 
   # The path(s) to the file(s) to use as an input.
   # You can use filename patterns here, such as `/var/log/*.log`.

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.3.1'
+  s.version         = '4.4.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-multiline', ['~> 3.0']
-  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.1'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
 
   s.add_development_dependency 'stud', ['~> 0.0.19']
   s.add_development_dependency 'logstash-devutils'

--- a/spec/inputs/file_tail_spec.rb
+++ b/spec/inputs/file_tail_spec.rb
@@ -103,7 +103,7 @@ describe LogStash::Inputs::File do
 
 
     context "when path and host fields exist", :ecs_compatibility_support do
-      ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
+      ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
 
         before(:each) do
           allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)


### PR DESCRIPTION
Since there are no relevant changes between the upcoming ECS v8 and the existing ECS v1, add an alias to support `v8`.