### PR TITLE
Fix broken identity map flush test

### DIFF
--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -57,7 +57,8 @@ module FileInput
       @tracer.push [:close, true]
     end
     def clone
-      self.class.new
+      @tracer.push [:clone, true]
+      self
     end
   end
 end


### PR DESCRIPTION
Following https://github.com/logstash-plugins/logstash-codec-multiline/pull/70,
clones of the codec are used, rather than the original codec, causing the codec
tracer not to be able to trace events that occurred after the clone. This
commit removes the physical clone on the CodecTracer, rather treating it as another
function to be traced, returning the same Tracer instance, but adding a clone event
instead.