### PR TITLE
Fix ReadFile handler to consider the value stored in sincedb on plugin restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.3
+  - Fixes read mode to restart the read from reference stored in sincedb in case the file wasn't completely consumed. [#307](https://github.com/logstash-plugins/logstash-input-file/pull/307)
+
 ## 4.4.2
   - Doc: Fix attribute by removing extra character [#310](https://github.com/logstash-plugins/logstash-input-file/pull/310)
 

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -4,11 +4,8 @@ module FileWatch module ReadMode module Handlers
   class ReadFile < Base
     def handle_specifically(watched_file)
       if open_file(watched_file)
-        add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
-        if sincedb_collection.member?(watched_file.sincedb_key)
-          previous_pos = sincedb_collection.find(watched_file).position
-          watched_file.file_seek([watched_file.bytes_read, previous_pos].max)
-        end
+        add_or_update_sincedb_collection(watched_file)
+        watched_file.file_seek(watched_file.bytes_read)
         loop do
           break if quit?
           loop_control = watched_file.loop_control_adjusted_for_stat_size

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -5,6 +5,10 @@ module FileWatch module ReadMode module Handlers
     def handle_specifically(watched_file)
       if open_file(watched_file)
         add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
+        if sincedb_collection.member?(watched_file.sincedb_key)
+          previous_pos = sincedb_collection.find(watched_file).position
+          watched_file.file_seek([watched_file.bytes_read, previous_pos].max)
+        end
         loop do
           break if quit?
           loop_control = watched_file.loop_control_adjusted_for_stat_size

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -2,11 +2,19 @@
 
 module FileWatch module ReadMode module Handlers
   class ReadFile < Base
+
+    # seek file to which ever is furthest: either current bytes read or sincedb position
+    private
+    def seek_to_furthest_position(watched_file)
+      previous_pos = sincedb_collection.find(watched_file).position
+      watched_file.file_seek([watched_file.bytes_read, previous_pos].max)
+    end
+
+    public
     def handle_specifically(watched_file)
       if open_file(watched_file)
         add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
-        previous_pos = sincedb_collection.find(watched_file).position
-        watched_file.file_seek([watched_file.bytes_read, previous_pos].max)
+        seek_to_furthest_position(watched_file)
         loop do
           break if quit?
           loop_control = watched_file.loop_control_adjusted_for_stat_size

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -4,8 +4,9 @@ module FileWatch module ReadMode module Handlers
   class ReadFile < Base
     def handle_specifically(watched_file)
       if open_file(watched_file)
-        add_or_update_sincedb_collection(watched_file)
-        watched_file.file_seek(watched_file.bytes_read)
+        add_or_update_sincedb_collection(watched_file) unless sincedb_collection.member?(watched_file.sincedb_key)
+        previous_pos = sincedb_collection.find(watched_file).position
+        watched_file.file_seek([watched_file.bytes_read, previous_pos].max)
         loop do
           break if quit?
           loop_control = watched_file.loop_control_adjusted_for_stat_size

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.4.2'
+  s.version         = '4.4.3'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filewatch/read_mode_handlers_read_file_spec.rb
+++ b/spec/filewatch/read_mode_handlers_read_file_spec.rb
@@ -36,5 +36,45 @@ module FileWatch
         processor.read_file(watched_file)
       end
     end
+
+    context "when restart from existing sincedb" do
+      let(:settings) do
+        Settings.from_options(
+          :sincedb_write_interval => 0,
+          :sincedb_path => File::NULL,
+          :file_chunk_size => 10
+        )
+      end
+
+      let(:processor) { double("fake processor") }
+      let(:observer) { TestObserver.new }
+      let(:watch) { double("watch") }
+
+      before(:each) {
+        allow(watch).to receive(:quit?).and_return(false)#.and_return(false).and_return(true)
+        allow(processor).to receive(:watch).and_return(watch)
+      }
+
+      it "read from where it left" do
+        listener = observer.listener_for(Pathname.new(pathname).to_path)
+        sut = ReadMode::Handlers::ReadFile.new(processor, sdb_collection, observer, settings)
+
+        # simulate a previous partial read of the file
+        sincedb_value = SincedbValue.new(0)
+        sincedb_value.set_watched_file(watched_file)
+        sdb_collection.set(watched_file.sincedb_key, sincedb_value)
+
+
+        # simulate a consumption of first line, (size + newline) bytes
+        sdb_collection.increment(watched_file.sincedb_key, File.readlines(pathname)[0].size + 2)
+
+        # exercise
+        sut.handle(watched_file)
+
+        # verify
+        expect(listener.lines.size).to eq(1)
+        expect(listener.lines[0]).to start_with("2010-03-12   23:51:21   SEA4   192.0.2.222   play   3914   OK")
+      end
+    end
   end
 end

--- a/spec/filewatch/spec_helper.rb
+++ b/spec/filewatch/spec_helper.rb
@@ -80,6 +80,8 @@ module FileWatch
       multiplier = amount / string.length
       string * multiplier
     end
+    def sysseek(offset, whence)
+    end
   end
 
   FIXTURE_DIR = File.join('spec', 'fixtures')

--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -31,7 +31,13 @@ module FileInput
 
     def trace_for(symbol)
       params = @tracer.map {|k,v| k == symbol ? v : nil}.compact
-      params.empty? ? false : params
+      if params.empty?
+        false
+      else
+        # merge all params with same key
+        # there could be multiple instances of same call, e.g. [[:accept, true], [:auto_flush, true], [:close, true], [:auto_flush, true]]
+        params.reduce {|b1, b2| b1 and b2}
+      end
     end
 
     def clear

--- a/spec/inputs/file_tail_spec.rb
+++ b/spec/inputs/file_tail_spec.rb
@@ -332,7 +332,7 @@ describe LogStash::Inputs::File do
           .then("wait accept") do
             wait(0.75).for {
               subject.codec.identity_map[tmpfile_path].codec.trace_for(:accept)
-            }.to eq([true]), "accept didn't"
+            }.to eq(true), "accept didn't"
           end
           .then("request a stop") do
             # without this the subject.run doesn't invokes the #exit_flush which is the only @codec.flush_mapped invocation
@@ -341,12 +341,11 @@ describe LogStash::Inputs::File do
           .then("wait for auto_flush") do
             wait(2).for {
               subject.codec.identity_map[tmpfile_path].codec.trace_for(:auto_flush)
-                .reduce {|b1, b2| b1 and b2} # there could be multiple instances of same call, e.g. [[:accept, true], [:auto_flush, true], [:close, true], [:auto_flush, true]]
             }.to eq(true), "autoflush didn't"
           end
         subject.run(events)
         actions.assert_no_errors
-        expect(subject.codec.identity_map[tmpfile_path].codec.trace_for(:accept)).to eq([true])
+        expect(subject.codec.identity_map[tmpfile_path].codec.trace_for(:accept)).to eq(true)
       end
     end
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Fixes read mode when sincedb already stores a reference for the file not completely consumed.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Update the file pointer of a read mode file to the max between the read bytes or the sincedb reference for the same file.
This solves a problem, that when a pipeline is restarted, it's able to recover from the last known reference, without restarting from the beginning, and reprocessing already processed lines.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
When a pipeline with file input in read mode is restarted, this let the plugin to recover from where it left if that information is present in the sincedb store.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] verify with the steps used in the bug report #240. I used the following test file:
[sample_fixture.csv.txt](https://github.com/logstash-plugins/logstash-input-file/files/8398354/sample_fixture.csv.txt)

Pipeline definition:
```
- pipeline.id: SDH_650
  pipeline.workers: 1
  pipeline.batch.size: 5
  config.string: |
    input {
        file {
            path => "/home/andrea/workspace/logstash_configs/file_input_sdh650/sample_fixture.csv"
            sincedb_path => "/home/andrea/workspace/logstash_configs/file_input_sdh650/sincedb"
            mode  => "read"
            start_position => "beginning"
        }
    }

    filter {
        csv {
            separator => ","
            columns => ["id", "host", "fqdn", "IP", "mac", "role", "type", "make", "model", "oid", "fid", "time"]
            remove_field => ["path", "host", "message", "@version" ]   
        }
        sleep {
            time => 1
            every => 10
        }
    }

    output {
        elasticsearch { 
            index => "650" 
            hosts => "http://localhost:9200"
            user => "elastic"
            password => "changeme"
        }
        stdout { codec => dots }
    }

```

Some curls to configure the ES output index and an aggregation query to verify:
```
PUT /650
{
  "mappings": {
    "properties": {
      "id":    { "type": "keyword" },  
      "host":  { "type": "text"  }, 
      "fqdn":   { "type": "text"  },
      "IP":   { "type": "text"  },
      "mac":   { "type": "text"  },
      "role":   { "type": "keyword"  },
      "type":   { "type": "keyword"  },
      "make":   { "type": "text"  },
      "model":   { "type": "text"  },
      "oid":   { "type": "text"  },
      "fid":   { "type": "text"  },
      "time":   { "type": "text"  }
    }
  }
}
DELETE 650

GET 650/_search
{
  "aggs": {
    "types": {
      "terms": { "field": "type" }
    }
  }
}
``` 

The expectation is to have 2 buckets, equally sized. Without the fix a bucket contains more documents, which means some rows was reprocessed on a pipeline reload.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Follow step steps in #290  

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #290

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
