### PR TITLE
Doc: Set version attribute in plugin source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Unreleased
+## 4.4.1
   - Fix: update to Gradle 7 [#305](https://github.com/logstash-plugins/logstash-input-file/pull/305)
+  - [DOC] Add version attributes to doc source file [#308](https://github.com/logstash-plugins/logstash-input-file/pull/308)
   
 ## 4.4.0
   - Add support for ECS v8 [#301](https://github.com/logstash-plugins/logstash-input-file/pull/301)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@
 
 ifeval::["{versioned_docs}"=="true"]
 :branch: %BRANCH%
-:ecs_version: %BRANCH%
+:ecs_version: %ECS_VERSION%
 endif::[]
 
 ///////////////////////////////////////////

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,11 +2,6 @@
 :type: input
 :default_codec: plain
 
-ifeval::["{versioned_docs}"=="true"]
-:branch: %BRANCH%
-:ecs_version: %ECS_VERSION%
-endif::[]
-
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
@@ -14,6 +9,11 @@ START - GENERATED VARIABLES, DO NOT EDIT!
 :release_date: %RELEASE_DATE%
 :changelog_url: %CHANGELOG_URL%
 :include_path: ../../../../logstash/docs/include
+
+ifeval::["{versioned_docs}"=="true"]
+:branch: %BRANCH%
+:ecs_version: %ECS_VERSION%
+endif::[]
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
@@ -87,7 +87,7 @@ was not ideal and a dedicated Read mode is an improvement.
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 This plugin adds metadata about event's source, and can be configured to do so
-in an https://www.elastic.co/guide/en/ecs/{ecs-version}/index.html[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
+in an https://www.elastic.co/guide/en/ecs/{ecs_version}/index.html[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
 This metadata is added after the event has been decoded by the appropriate codec,
 and will never overwrite existing values.
 
@@ -275,7 +275,7 @@ In practice, this will be the best case because the time taken to read new conte
 ** Otherwise, the default value is `disabled`.
 
 Controls this plugin's compatibility with the
-https://www.elastic.co/guide/en/ecs/{ecs-version}/index.html[Elastic Common Schema (ECS)].
+https://www.elastic.co/guide/en/ecs/{ecs_version}/index.html[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-exclude"]
 ===== `exclude`
@@ -444,7 +444,7 @@ The sincedb record now has a last active timestamp associated with it.
 If no changes are detected in a tracked file in the last N days its sincedb
 tracking record expires and will not be persisted.
 This option helps protect against the inode recycling problem.
-Filebeat has a https://www.elastic.co/guide/en/beats/filebeat/{branch}}/inode-reuse-issue.html[FAQ about inode recycling].
+Filebeat has an https://www.elastic.co/guide/en/beats/filebeat/{branch}}/inode-reuse-issue.html[FAQ about inode recycling].
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,6 +2,11 @@
 :type: input
 :default_codec: plain
 
+ifeval::["{versioned_docs}"=="true"]
+:branch: %BRANCH%
+:ecs_version: %BRANCH%
+endif::[]
+
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
@@ -532,5 +537,10 @@ Supported values: `ms` `msec` `msecs`, e.g. "500 ms", "750 msec", "50 msecs
 Supported values: `us` `usec` `usecs`, e.g. "600 us", "800 usec", "900 usecs"
 [NOTE]
 `micro` `micros` and `microseconds` are not supported
+
+ifeval::["{versioned_docs}"=="true"]
+:branch: current
+:ecs_version: current
+endif::[]
 
 :default_codec!:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -87,7 +87,7 @@ was not ideal and a dedicated Read mode is an improvement.
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 This plugin adds metadata about event's source, and can be configured to do so
-in an {ecs-ref}[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
+in an https://www.elastic.co/guide/en/ecs/{ecs-version}/index.html[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
 This metadata is added after the event has been decoded by the appropriate codec,
 and will never overwrite existing values.
 
@@ -275,7 +275,7 @@ In practice, this will be the best case because the time taken to read new conte
 ** Otherwise, the default value is `disabled`.
 
 Controls this plugin's compatibility with the
-{ecs-ref}[Elastic Common Schema (ECS)].
+https://www.elastic.co/guide/en/ecs/{ecs-version}/index.html[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-exclude"]
 ===== `exclude`
@@ -431,7 +431,7 @@ of `/var/log` will be done for all `*.log` files.
 Paths must be absolute and cannot be relative.
 
 You may also configure multiple paths. See an example
-on the {logstash-ref}/configuration-file-structure.html#array[Logstash configuration page].
+on the https://www.elastic.co/guide/en/logstash/{branch}/configuration-file-structure.html#array[Logstash configuration page].
 
 [id="plugins-{type}s-{plugin}-sincedb_clean_after"]
 ===== `sincedb_clean_after`
@@ -444,7 +444,7 @@ The sincedb record now has a last active timestamp associated with it.
 If no changes are detected in a tracked file in the last N days its sincedb
 tracking record expires and will not be persisted.
 This option helps protect against the inode recycling problem.
-Filebeat has a {filebeat-ref}/inode-reuse-issue.html[FAQ about inode recycling].
+Filebeat has a https://www.elastic.co/guide/en/beats/filebeat/{branch}}/inode-reuse-issue.html[FAQ about inode recycling].
 
 [id="plugins-{type}s-{plugin}-sincedb_path"]
 ===== `sincedb_path`

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.4.0'
+  s.version         = '4.4.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Related to plugin versioning work in https://github.com/elastic/docs-tools/pull/70 and https://github.com/elastic/docs-tools/pull/73.
The stack version attributes must be (calculated and) set on a per file basis, as the stack version will increment over time. I believe that this approach represents the right place to set those attributes. 

#### Notes
* I've used conditionals to ensure that the version attributes are set for the Versioned Plugin Reference only. 
  * Why? The Logstash Reference is stack versioned, and we don't want the VPR approximations to interfere by causing unintended consequences. 
* When tested and approved, these attribute settings need to be added for each plugin affected by versioning problems (output-elasticsearch, input-beats, etc.)  Don't worry... I know the list. 😄 
* When the versioning work has been implemented and fully functional, the VPR will need some cleanup to remove past "band-aids" to versioning. 
  *  When the cleanup work is complete, I'll remove the attribute resets at the end of each source file. 


