### PR TITLE
Fix failing tests

### DIFF
--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -57,7 +57,7 @@ module FileInput
       @tracer.push [:close, true]
     end
     def clone
-      self.class.new
+      self
     end
   end
 end

--- a/spec/inputs/file_tail_spec.rb
+++ b/spec/inputs/file_tail_spec.rb
@@ -329,8 +329,10 @@ describe LogStash::Inputs::File do
           .then_after(0.1, "identity is mapped") do
             wait(0.75).for{subject.codec.identity_map[tmpfile_path]}.not_to be_nil, "identity is not mapped"
           end
-          # without this the subject.run doesn't invokes the #exit_flush which is the only @codec.flush_mapped invokation
-          .then("request a stop") { subject.stop }
+          .then("request a stop") do
+            # without this the subject.run doesn't invokes the #exit_flush which is the only @codec.flush_mapped invocation
+            subject.stop
+          end
           .then("wait for auto_flush") do
             wait(0.75).for {
               subject.codec.identity_map[tmpfile_path].codec.trace_for(:auto_flush)

--- a/spec/inputs/file_tail_spec.rb
+++ b/spec/inputs/file_tail_spec.rb
@@ -339,7 +339,7 @@ describe LogStash::Inputs::File do
             subject.stop
           end
           .then("wait for auto_flush") do
-            wait(0.75).for {
+            wait(2).for {
               subject.codec.identity_map[tmpfile_path].codec.trace_for(:auto_flush)
                 .reduce {|b1, b2| b1 and b2} # there could be multiple instances of same call, e.g. [[:accept, true], [:auto_flush, true], [:close, true], [:auto_flush, true]]
             }.to eq(true), "autoflush didn't"


### PR DESCRIPTION
## Release notes

[rn:skip] 

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This PR fixes some failing tests on `main`

There are two failures that this PR fixes:
- tests that referred `host` or `path` attribute running against Logstash 8, which by default has ECS enabled.
The fix consisted in surrounding the test with the ECS harness and use the `ecs_select` to refer attributes with proper name.
- another fix regards the test `having timed_out, the codec is auto flushed`. It presented 2 problems:
  - the first is that to request the `subject.stop` to trigger the `auto_flush` call (called by `exit_flush` method).
  - the second regard a regression introduced with https://github.com/logstash-plugins/logstash-codec-multiline/pull/70. The test worked because the the `IdentityMapCodec` used a shared codec. When this behavior was removed the test, that engage multiple threads, exposed a problem of overwriting of codec reference. This overwriting drove to the lost of data, used in test logic. The fix consists in [clone redefinition](https://github.com/logstash-plugins/logstash-input-file/pull/309/commits/068dc41b6a829e0323a052e8a8de198258236d3a#diff-f65f19650794af07033d902e6875428449f6a5353a266e54b1a7281aebe66233L60) to make it almost a singleton.

## Why is it important/What is the impact to the user?

Make the test green increase the confidence in the code base.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Related https://github.com/logstash-plugins/logstash-codec-multiline/pull/70