### PR TITLE
Avoid to call JDK package private method into BufferedReader

### DIFF
--- a/lib/filewatch/read_mode/handlers/read_zip_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_zip_file.rb
@@ -29,7 +29,7 @@ module FileWatch module ReadMode module Handlers
           gzip_stream = GZIPInputStream.new(file_stream)
           decoder = InputStreamReader.new(gzip_stream, "UTF-8")
           buffered = BufferedReader.new(decoder)
-          while (line = buffered.readLine(false))
+          while (line = buffered.readLine())
             watched_file.listener.accept(line)
             # can't quit, if we did then we would incorrectly write a 'completed' sincedb entry
             # what do we do about quit when we have just begun reading the zipped file (e.g. pipeline reloading)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

Avoid to call a `Bufferedreader` 's  `package-private` and switch to the public version.

Package private methods mustn't be called also if JRuby permit us. With JDK the signature of the method changed:
- [JDK 11](https://github.com/openjdk/jdk11u/blob/master/src/java.base/share/classes/java/io/BufferedReader.java#L314) 
- [JDK 17](https://github.com/openjdk/jdk17u/blob/master/src/java.base/share/classes/java/io/BufferedReader.java#L316) 

However `readLine(false)` is what was done on the [JDK 11](https://github.com/openjdk/jdk11u/blob/1dd942d3541431b21403f39b4cc5943271b59801/src/java.base/share/classes/java/io/BufferedReader.java#L391-L393)

## Why is it important/What is the impact to the user?

Make the the plugin testable under JDK 17+

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run with JDK 17

## How to test this PR locally
- install a JDK 17 on local environment
- point LOGSTASH_PATH and set LOGSTASH_SOURCE=1
- install a jruby equals to the version shipped with Logstash 
```
rvm install jruby 9.3.4.0
```
- export some packages
```bash
export JRUBY_OPTS="-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
```
- run the specs
```
clear; bundler exec rspec
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


