### PR TITLE
handle EOF when checking archive validity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.5
+  - Handle EOF when checking archive validity [#321](https://github.com/logstash-plugins/logstash-input-file/pull/321)
+
 ## 4.4.4
   - Fixes gzip file handling in read mode when run on JDK12+, including JDK17 that is bundled with Logstash 8.4+ [#312](https://github.com/logstash-plugins/logstash-input-file/pull/312)
 

--- a/lib/filewatch/read_mode/handlers/read_zip_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_zip_file.rb
@@ -71,14 +71,14 @@ module FileWatch module ReadMode module Handlers
 
     def corrupted?(watched_file)
       begin
+        start = Time.new
         file_stream = FileInputStream.new(watched_file.path)
         gzip_stream = GZIPInputStream.new(file_stream)
         buffer = Java::byte[8192].new
-        start = Time.new
         until gzip_stream.read(buffer) == -1
         end
         return false
-      rescue ZipException => e
+      rescue ZipException, Java::JavaIo::EOFException => e
         duration = Time.now - start
         logger.warn("Detected corrupted archive #{watched_file.path} file won't be processed", :message => e.message,
                     :duration => duration.round(3))

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.4.4'
+  s.version         = '4.4.5'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -24,6 +24,12 @@ module FileInput
     f.close()
   end
 
+  def self.truncate_gzip(file_path)
+    f = File.open(file_path, "ab")
+    f.truncate(100)
+    f.close()
+  end
+
   class TracerBase
     def initialize
       @tracer = Concurrent::Array.new


### PR DESCRIPTION
if the gzip file is truncated the EOF exception must be handled during archive validity check.

To test, create a truncated gzip file:
```
/tmp ❯ echo "1234567890" | gzip > a.gz
/tmp ❯ dd if=a.gz of=a.truncated.gz bs=1 count=5
5+0 records in
5+0 records out
5 bytes transferred in 0.000263 secs (19011 bytes/sec)
```
Then start Logstash:

```
bin/logstash -e "input { file { path => '/tmp/a.truncated.gz' sincedb_path => '/dev/null' mode => read check_archive_validity => true start_position => 'beginning' file_completed_action => log file_completed_log_path => '/tmp/log' } } "
```

closes https://github.com/logstash-plugins/logstash-input-file/issues/300