### PR TITLE
Change read mode to immediately stop consuming lines when shutting down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.6
+  - Change read mode to immediately stop consuming buffered lines when shutdown is requested [#322](https://github.com/logstash-plugins/logstash-input-file/pull/322)
+
 ## 4.4.5
   - Handle EOF when checking archive validity [#321](https://github.com/logstash-plugins/logstash-input-file/pull/321)
 

--- a/lib/filewatch/read_mode/handlers/read_file.rb
+++ b/lib/filewatch/read_mode/handlers/read_file.rb
@@ -54,6 +54,7 @@ module FileWatch module ReadMode module Handlers
             # sincedb position is independent from the watched_file bytes_read
             delta = line.bytesize + @settings.delimiter_byte_size
             sincedb_collection.increment(watched_file.sincedb_key, delta)
+            break if quit?
           end
         rescue EOFError => e
           log_error("controlled_read: eof error reading file", watched_file, e)

--- a/logstash-input-file.gemspec
+++ b/logstash-input-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-file'
-  s.version         = '4.4.5'
+  s.version         = '4.4.6'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Streams events from files"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR changes the read mode to immediately stop consuming buffered lines when the pipeline shutdown is requested.

---
Closes: https://github.com/logstash-plugins/logstash-input-file/issues/323

