### PR TITLE
Completely ignore files older then 'ignore_older' setting

### DIFF
--- a/lib/filewatch/discoverer.rb
+++ b/lib/filewatch/discoverer.rb
@@ -36,6 +36,13 @@ module FileWatch
     private
 
     def can_exclude?(watched_file, new_discovery)
+      if watched_file.file_ignorable?
+        if new_discovery
+          logger.trace("skipping file because it is too old", :path => watched_file.path)
+        end
+        watched_file.unwatch
+        return true
+      end
       @exclude.each do |pattern|
         if watched_file.pathname.basename.fnmatch?(pattern)
           if new_discovery

--- a/lib/filewatch/watched_file.rb
+++ b/lib/filewatch/watched_file.rb
@@ -187,7 +187,8 @@ module FileWatch
     end
 
     def set_accessed_at
-      @accessed_at = Time.now.to_f
+      # if files older then specific time should be ignored - take last change time as last access time
+      @accessed_at = if expiry_ignore_enabled? then File.mtime(@path).to_f else Time.now.to_f end
     end
 
     def initial?


### PR DESCRIPTION
RE: Elastic support case #01555020 

Completely ignore files older then 'ignore_older' setting because we have hundreds of thousands of files in the same folder (logs from a 3d party app) but need to monitor/ingest only recent