### PR TITLE
Make file completion tests deterministic

### DIFF
--- a/spec/filewatch/reading_spec.rb
+++ b/spec/filewatch/reading_spec.rb
@@ -48,7 +48,7 @@ module FileWatch
           reading.watch_this(watch_dir)
         end
         .then("wait") do
-          wait(2).for{listener1.calls.last}.to eq(:delete)
+          wait(2).for{listener1.calls_history.last}.to eq(:delete)
         end
         .then("quit") do
           reading.quit
@@ -58,7 +58,7 @@ module FileWatch
         actions.activate_quietly
         reading.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :accept, :eof, :delete])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept, :eof, :delete])
         expect(listener1.lines).to eq(["line1", "line2"])
       end
     end
@@ -73,7 +73,7 @@ module FileWatch
           reading.watch_this(watch_dir)
         end
         .then("wait") do
-          wait(2).for{listener1.calls.last}.to eq(:delete)
+          wait(2).for{listener1.calls_history.last}.to eq(:delete)
         end
         .then("quit") do
           reading.quit
@@ -83,7 +83,7 @@ module FileWatch
         actions.activate_quietly
         reading.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :accept, :eof, :delete])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept, :eof, :delete])
         expect(listener1.lines).to eq(["line1", "line2"])
       end
     end
@@ -104,7 +104,7 @@ module FileWatch
           reading.watch_this(watch_dir)
         end
         .then("wait") do
-          wait(2).for{listener1.calls.last == :delete && listener2.calls.last == :delete}.to eq(true)
+          wait(2).for{listener1.calls_history.last == :delete && listener2.calls_history.last == :delete}.to eq(true)
         end
         .then("quit") do
           reading.quit
@@ -114,8 +114,8 @@ module FileWatch
         actions.activate_quietly
         reading.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :accept, :eof, :delete])
-        expect(listener2.calls).to eq([:open, :accept, :accept, :eof, :delete])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept, :eof, :delete])
+        expect(listener2.calls_history).to eq([:open, :accept, :accept, :eof, :delete])
         expect(lines).to eq(%w(string1 stringA string2 stringB))
       end
     end
@@ -130,7 +130,7 @@ module FileWatch
           reading.watch_this(watch_dir)
         end
         .then("wait") do
-          wait(2).for{listener1.calls.last}.to eq(:delete)
+          wait(2).for{listener1.calls_history.last}.to eq(:delete)
         end
         .then("quit") do
           reading.quit
@@ -140,7 +140,7 @@ module FileWatch
         actions.activate_quietly
         reading.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :eof, :delete])
+        expect(listener1.calls_history).to eq([:open, :accept, :eof, :delete])
         expect(listener1.lines).to eq(["line1\nline2"])
         sincedb_record_fields = File.read(sincedb_path).split(" ")
         position_field_index = 3
@@ -171,13 +171,13 @@ module FileWatch
           reading.watch_this(watch_dir)
         end
         .then("wait12") do
-          wait(2).for { listener1.calls.last == :delete && listener2.calls.last == :delete }.to eq(true)
+          wait(2).for { listener1.calls_history.last == :delete && listener2.calls_history.last == :delete }.to eq(true)
         end
         .then_after(2, "create3") do
           File.open(file_path3, "w") { |file| file.write("string31\nstring32") }
         end
         .then("wait3") do
-          wait(2).for { listener3.calls.last == :delete }.to eq(true)
+          wait(2).for { listener3.calls_history.last == :delete }.to eq(true)
         end
         .then("quit") do
           reading.quit
@@ -233,7 +233,7 @@ module FileWatch
         File.open(file_path3, "w") { |file| file.write("line1\nline2\n") }
         reading.watch_this(watch_dir)
         reading.subscribe(observer)
-        expect(listener3.calls).to eq([:open, :accept, :accept, :eof, :delete, :reading_completed])
+        expect(listener3.calls_history).to eq([:open, :accept, :accept, :eof, :delete, :reading_completed])
       end
 
       it "sincedb works correctly" do
@@ -251,8 +251,8 @@ module FileWatch
         reading.subscribe(observer)
         File.open(file_path6, "w") { |file|  file.write("foob\nbar\n") }
         expect(listener3.lines).to eq(["line1", "line2"])
-        expect(listener3.calls).to eq([:open, :accept, :accept, :eof, :delete, :reading_completed])
-        expect(listener6.calls).to eq([])
+        expect(listener3.calls_history).to eq([:open, :accept, :accept, :eof, :delete, :reading_completed])
+        expect(listener6.calls_history).to eq([])
       end
     
     end
@@ -264,7 +264,7 @@ module FileWatch
           reading.watch_this(watch_dir)
         end
         .then("wait") do
-          wait(1).for{listener1.calls.last}.to eq(:delete)
+          wait(1).for{listener1.calls_history.last}.to eq(:delete)
         end
         .then("quit") do
           reading.quit
@@ -279,7 +279,7 @@ module FileWatch
           actions.activate_quietly
           reading.subscribe(observer)
           actions.assert_no_errors
-          expect(listener1.calls).to eq([:open, :accept, :accept, :eof, :delete])
+          expect(listener1.calls_history).to eq([:open, :accept, :accept, :eof, :delete])
           expect(listener1.lines.size).to eq(2)
         end
       end
@@ -293,7 +293,7 @@ module FileWatch
           actions.activate_quietly
           reading.subscribe(observer)
           actions.assert_no_errors
-          expect(listener1.calls).to eq([:open, :accept, :accept, :eof, :delete])
+          expect(listener1.calls_history).to eq([:open, :accept, :accept, :eof, :delete])
           expect(listener1.lines.size).to eq(2)
         end
       end
@@ -307,7 +307,7 @@ module FileWatch
           actions.activate_quietly
           reading.subscribe(observer)
           actions.assert_no_errors
-          expect(listener1.calls).to eq([:open, :accept, :accept, :eof, :delete])
+          expect(listener1.calls_history).to eq([:open, :accept, :accept, :eof, :delete])
           expect(listener1.lines.size).to eq(2)
         end
       end

--- a/spec/filewatch/rotate_spec.rb
+++ b/spec/filewatch/rotate_spec.rb
@@ -74,7 +74,7 @@ module FileWatch
           end
           .then("wait for expectation") do
             sleep(0.25) # if ENV['CI']
-            wait(2).for { listener1.calls }.to eq([:open, :accept, :accept, :accept])
+            wait(2).for { listener1.calls_history }.to eq([:open, :accept, :accept, :accept])
           end
           .then("quit") do
             tailing.quit
@@ -255,7 +255,7 @@ module FileWatch
         actions.assert_no_errors
         expected_calls = ([:accept] * 66).unshift(:open)
         expect(listener1.lines.uniq).to eq([line1])
-        expect(listener1.calls).to eq(expected_calls)
+        expect(listener1.calls_history).to eq(expected_calls)
         expect(sincedb_path.readlines.size).to eq(2)
       end
     end
@@ -291,7 +291,7 @@ module FileWatch
         tailing.subscribe(observer)
         actions.assert_no_errors
         expect(listener1.lines).to eq([line1, line2, line3])
-        expect(listener1.calls).to eq([:open, :accept, :accept, :accept])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept, :accept])
       end
     end
 

--- a/spec/filewatch/sincedb_collection_spec.rb
+++ b/spec/filewatch/sincedb_collection_spec.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+require 'stud/temporary'
+require_relative 'spec_helper'
+require 'filewatch/sincedb_collection'
+
+module FileWatch
+  describe SincedbCollection do
+    let(:sincedb_path) { Stud::Temporary.pathname }
+    let(:now) { Time.now.to_f }
+    let(:expired_key) { InodeStruct.new('expired', 1, 1) }
+    let(:active_key) { InodeStruct.new('active', 1, 1) }
+    let(:settings) do
+      Settings.from_options(
+        :sincedb_path => sincedb_path,
+        :sincedb_clean_after => 3600,
+        :sincedb_write_interval => 0
+      )
+    end
+
+    subject(:collection) { described_class.new(settings) }
+
+    before do
+      collection.set(expired_key, SincedbValue.new(42, now - 7200))
+      collection.set(active_key, SincedbValue.new(99, now))
+      collection.flush_at_interval
+    end
+
+    it 'removes expired entries from the collection' do
+      expect(collection.keys).to contain_exactly(active_key)
+    end
+
+    it 'does not persist expired entries' do
+      expect(File.read(sincedb_path)).to eq("#{active_key} 99 #{now}\n")
+    end
+  end
+end

--- a/spec/filewatch/spec_helper.rb
+++ b/spec/filewatch/spec_helper.rb
@@ -117,47 +117,56 @@ module FileWatch
 
   class TestObserver
     class Listener
-      attr_reader :path, :lines, :calls
+      attr_reader :path, :lines, :calls_history
 
-      def initialize(path, lines)
+      def initialize(path, lines, notification_queue)
         @path = path
         @lines = lines || Concurrent::Array.new
-        @calls = Concurrent::Array.new
+        @calls_history = Concurrent::Array.new
+        @notification_queue = notification_queue
       end
 
       def accept(line)
         @lines << line
-        @calls << :accept
+        record(:accept)
       end
 
       def deleted
-        @calls << :delete
+        record(:delete)
       end
 
       def opened
-        @calls << :open
+        record(:open)
       end
 
       def error
-        @calls << :error
+        record(:error)
       end
 
       def eof
-        @calls << :eof
+        record(:eof)
       end
 
       def timed_out
-        @calls << :timed_out
+        record(:timed_out)
       end
 
       def reading_completed
-        @calls << :reading_completed
+        record(:reading_completed)
+      end
+
+      private
+
+      def record(event)
+        @calls_history << event
+        @notification_queue << [@path, event] unless @notification_queue.nil?
       end
     end
 
     attr_reader :listeners
 
-    def initialize(combined_lines = nil)
+    def initialize(combined_lines = nil, notification_queue = nil)
+      @notification_queue = notification_queue
       @listeners = Concurrent::Hash.new { |hash, key| hash[key] = new_listener(key, combined_lines) }
     end
 
@@ -172,7 +181,7 @@ module FileWatch
     private
 
     def new_listener(path, lines = nil)
-      Listener.new(path, lines)
+      Listener.new(path, lines, @notification_queue)
     end
 
   end

--- a/spec/filewatch/tailing_spec.rb
+++ b/spec/filewatch/tailing_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'stud/temporary'
+require 'timeout'
 require_relative 'spec_helper'
 require 'filewatch/observing_tail'
 
@@ -43,14 +44,24 @@ module FileWatch
 
     describe "max open files (set to 1)" do
       let(:max) { 1 }
-      let(:wait_before_quit) { 0.15 }
       let(:stat_interval) { 0.01 }
       let(:discover_interval) { 4 }
       let(:start_new_files_at) { :beginning }
+      let(:listener_notification_queue) { Queue.new }
+      let(:observer) { TestObserver.new(nil, listener_notification_queue) }
+      let(:completion_listener) { listener1 }
+      let(:expected_calls_history) { [:open, :accept, :accept] }
       let(:actions) do
         RSpec::Sequencing
-          .run_after(wait_before_quit, "quit after a short time") do
-            tailing.quit
+          .run("quit after expected listener calls") do
+            begin
+              Timeout.timeout(30) do
+                # Block on listener notifications until the complete call history matches
+                listener_notification_queue.pop until completion_listener.calls_history == expected_calls_history
+              end
+            ensure
+              tailing.quit
+            end
           end
       end
 
@@ -70,24 +81,25 @@ module FileWatch
           actions.assert_no_errors
           expect(tailing.settings.max_active).to eq(max)
           expect(listener1.lines).to eq(["line1", "line2"])
-          expect(listener1.calls).to eq([:open, :accept, :accept])
-          expect(listener2.calls).to be_empty
+          expect(listener1.calls_history).to eq([:open, :accept, :accept])
+          expect(listener2.calls_history).to be_empty
         end
       end
 
       context "when close_older is set" do
-        let(:wait_before_quit) { 0.8 }
         let(:opts) { super().merge(:close_older => 0.1, :max_open_files => 1, :stat_interval => 0.1) }
         let(:suffix) { "B" }
+        let(:completion_listener) { listener2 }
+        let(:expected_calls_history) { [:open, :accept, :accept, :timed_out] }
         it "opens both files" do
           actions.activate_quietly
           tailing.watch_this(watch_dir)
           tailing.subscribe(observer)
           actions.assert_no_errors
           expect(tailing.settings.max_active).to eq(1)
-          expect(listener2.calls).to eq([:open, :accept, :accept, :timed_out])
+          expect(listener2.calls_history).to eq([:open, :accept, :accept, :timed_out])
           expect(listener2.lines).to eq(["line-A", "line-B"])
-          expect(listener1.calls).to eq([:open, :accept, :accept, :timed_out])
+          expect(listener1.calls_history).to eq([:open, :accept, :accept, :timed_out])
           expect(listener1.lines).to eq(["line1", "line2"])
         end
       end
@@ -118,7 +130,7 @@ module FileWatch
         actions.activate_quietly
         tailing.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :accept])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept])
         expect(listener1.lines).to eq(["line1", "line2"])
       end
     end
@@ -145,7 +157,7 @@ module FileWatch
         actions.activate_quietly
         tailing.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :accept])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept])
         expect(listener1.lines).to eq(["line1", "line2"])
       end
     end
@@ -171,7 +183,7 @@ module FileWatch
           RSpec::Sequencing.run_after(quit_after, "quit") { tailing.quit }
           tailing.subscribe(observer)
           expect(tailing.watch.watched_files_collection).to be_empty
-          expect(listener1.calls).to eq([:delete])
+          expect(listener1.calls_history).to eq([:delete])
         end
       end
 
@@ -181,7 +193,7 @@ module FileWatch
           RSpec::Sequencing.run_after(quit_after, "quit") { tailing.quit }
           tailing.subscribe(observer)
           expect(tailing.watch.watched_files_collection).to be_empty
-          expect(listener1.calls).to eq([:delete])
+          expect(listener1.calls_history).to eq([:delete])
         end
       end
 
@@ -191,7 +203,7 @@ module FileWatch
           RSpec::Sequencing.run_after(quit_after, "quit") { tailing.quit }
           tailing.subscribe(observer)
           expect(tailing.watch.watched_files_collection).to be_empty
-          expect(listener1.calls).to eq([:delete])
+          expect(listener1.calls_history).to eq([:delete])
         end
       end
 
@@ -201,7 +213,7 @@ module FileWatch
           RSpec::Sequencing.run_after(quit_after, "quit") { tailing.quit }
           tailing.subscribe(observer)
           expect(tailing.watch.watched_files_collection).to be_empty
-          expect(listener1.calls).to eq([:delete])
+          expect(listener1.calls_history).to eq([:delete])
         end
       end
     end
@@ -235,7 +247,7 @@ module FileWatch
         actions.activate_quietly
         tailing.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :accept, :accept, :accept, :accept, :accept])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept, :accept, :accept, :accept, :accept])
         expect(listener1.lines).to eq(["line1", "line2", "line3", "line4", "lineA", "lineB"])
       end
     end
@@ -269,9 +281,9 @@ module FileWatch
         actions.activate_quietly
         tailing.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :accept, :delete])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept, :delete])
         expect(listener1.lines).to eq(["line1", "line2"])
-        expect(new_file_listener.calls).to eq([])
+        expect(new_file_listener.calls_history).to eq([])
         expect(new_file_listener.lines).to eq([])
       end
     end
@@ -290,7 +302,7 @@ module FileWatch
             tailing.watch_this(watch_dir)
           end
           .then("wait") do
-            wait(0.5).for{listener1.calls.last}.to eq(:timed_out)
+            wait(0.5).for{listener1.calls_history.last}.to eq(:timed_out)
           end
           .then("rename file") do
             FileUtils.mv(file_path, file_path2)
@@ -311,9 +323,9 @@ module FileWatch
         tailing.subscribe(observer)
         actions.assert_no_errors
         expect(listener1.lines).to eq([])
-        expect(listener1.calls).to eq([:open, :timed_out, :delete])
+        expect(listener1.calls_history).to eq([:open, :timed_out, :delete])
         expect(listener2.lines).to eq(["line3", "line4"])
-        expect(listener2.calls).to eq([:open, :accept, :accept, :timed_out])
+        expect(listener2.calls_history).to eq([:open, :accept, :accept, :timed_out])
       end
     end
 
@@ -340,7 +352,7 @@ module FileWatch
         actions.activate_quietly
         tailing.subscribe(observer)
         actions.assert_no_errors
-        expect(listener1.calls).to eq([:open, :accept, :accept])
+        expect(listener1.calls_history).to eq([:open, :accept, :accept])
         expect(listener1.lines).to eq(["line3", "line4"])
       end
     end
@@ -354,7 +366,7 @@ module FileWatch
         end
         .then("watch and wait") do
           tailing.watch_this(watch_dir)
-          wait(1.25).for{listener1.calls}.to eq([:open, :timed_out])
+          wait(1.25).for{listener1.calls_history}.to eq([:open, :timed_out])
         end
         .then("quit") do
           tailing.quit
@@ -381,16 +393,16 @@ module FileWatch
             File.open(file_path, "wb") { |file|  file.write("line1\nline2\n") }
           end
           .then("wait for file to be read") do
-            wait(0.5).for{listener1.calls}.to eq([:open, :accept, :accept]), "file is not read"
+            wait(0.5).for{listener1.calls_history}.to eq([:open, :accept, :accept]), "file is not read"
           end
           .then("wait for file to be read and time out") do
-            wait(0.75).for{listener1.calls}.to eq([:open, :accept, :accept, :timed_out]), "file did not timeout the first time"
+            wait(0.75).for{listener1.calls_history}.to eq([:open, :accept, :accept, :timed_out]), "file did not timeout the first time"
           end
           .then("append more lines to file after file ages more than close_older") do
             File.open(file_path, "ab") { |file|  file.write("line3\nline4\n") }
           end
           .then("wait for last timeout") do
-            wait(0.75).for{listener1.calls}.to eq([:open, :accept, :accept, :timed_out, :open, :accept, :accept, :timed_out]), "file did not timeout the second time"
+            wait(0.75).for{listener1.calls_history}.to eq([:open, :accept, :accept, :timed_out, :open, :accept, :accept, :timed_out]), "file did not timeout the second time"
           end
           .then("quit") do
             tailing.quit
@@ -423,7 +435,7 @@ module FileWatch
       it "no files are read" do
         actions.activate_quietly
         tailing.subscribe(observer)
-        expect(listener1.calls).to eq([])
+        expect(listener1.calls_history).to eq([])
         expect(listener1.lines).to eq([])
       end
     end
@@ -451,8 +463,8 @@ module FileWatch
           end
           .then("wait") do
             wait(4).for do
-              listener1.lines.size == 32 && listener2.calls == [:delete] && listener3.calls == [:open, :accept, :timed_out]
-            end.to eq(true), "listener1.lines != 32 or listener2.calls != [:delete] or listener3.calls != [:open, :accept, :timed_out]"
+              listener1.lines.size == 32 && listener2.calls_history == [:delete] && listener3.calls_history == [:open, :accept, :timed_out]
+            end.to eq(true), "listener1.lines != 32 or listener2.calls_history != [:delete] or listener3.calls_history != [:open, :accept, :timed_out]"
           end
           .then("quit") do
             tailing.quit
@@ -481,7 +493,7 @@ module FileWatch
             tailing.watch_this(watch_dir)
           end
           .then("wait for lines") do
-            wait(1.5).for{listener1.calls}.to eq([:open, :accept, :accept, :timed_out])
+            wait(1.5).for{listener1.calls_history}.to eq([:open, :accept, :accept, :timed_out])
           end
           .then("quit") do
             tailing.quit
@@ -516,7 +528,7 @@ module FileWatch
       it "no files are read" do
         actions.activate_quietly
         tailing.subscribe(observer)
-        expect(listener1.calls).to eq([])
+        expect(listener1.calls_history).to eq([])
         expect(listener1.lines).to eq([])
       end
     end
@@ -535,7 +547,7 @@ module FileWatch
             File.open(file_path, "ab") { |file|  file.write("line3\nline4\n") }
           end
           .then("wait for lines") do
-            wait(2).for{listener1.calls}.to eq([:open, :accept, :accept, :timed_out])
+            wait(2).for{listener1.calls_history}.to eq([:open, :accept, :accept, :timed_out])
           end
           .then_after(0.1, "quit after allowing time to close the file") do
             tailing.quit
@@ -562,7 +574,7 @@ module FileWatch
             File.open(file_path, "wb") { |file|  file.write("line1\nline2") }
           end
           .then("wait for :timeout") do
-            wait(2).for{listener1.calls}.to eq([:open, :timed_out])
+            wait(2).for{listener1.calls_history}.to eq([:open, :timed_out])
           end
           .then_after(0.75, "quit after allowing time to close the file") do
             tailing.quit

--- a/spec/filewatch/watch_spec.rb
+++ b/spec/filewatch/watch_spec.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+require_relative 'spec_helper'
+require 'filewatch/watch'
+
+module FileWatch
+  describe Watch do
+    let(:watched_files) { double('watched files', :empty? => true, :close_all => nil) }
+    let(:discoverer) { double('discoverer', :watched_files_collection => watched_files) }
+    let(:processor) { double('processor', :add_watch => nil, :initialize_handlers => nil) }
+    let(:settings) do
+      double(
+        'settings',
+        :discover_interval => 2,
+        :exit_after_read => false,
+        :stat_interval => 0
+      )
+    end
+    let(:sincedb_collection) { double('sincedb collection', :write_if_requested => nil, :flush_at_interval => nil) }
+    let(:observer) { double('observer') }
+
+    subject(:watch) { described_class.new(discoverer, processor, settings) }
+
+    it 'flushes sincedb after each sleep interval' do
+      allow(watch).to receive(:sleep) { watch.quit }
+
+      watch.subscribe(observer, sincedb_collection)
+
+      expect(sincedb_collection).to have_received(:flush_at_interval).once
+    end
+  end
+end

--- a/spec/filewatch/watch_spec.rb
+++ b/spec/filewatch/watch_spec.rb
@@ -6,7 +6,7 @@ require 'filewatch/watch'
 module FileWatch
   describe Watch do
     let(:watched_files) { double('watched files', :empty? => true, :close_all => nil) }
-    let(:discoverer) { double('discoverer', :watched_files_collection => watched_files) }
+    let(:discoverer) { double('discoverer', :watched_files_collection => watched_files, :discover => nil) }
     let(:processor) { double('processor', :add_watch => nil, :initialize_handlers => nil) }
     let(:settings) do
       double(
@@ -23,11 +23,7 @@ module FileWatch
 
     it 'flushes sincedb after a sleep interval' do
       sleep_started = Queue.new
-      sleep_release = Queue.new
-      allow(watch).to receive(:sleep) do
-        sleep_started << true
-        sleep_release.pop
-      end
+      allow(watch).to receive(:sleep) { sleep_started << true if sleep_started.empty? }
 
       run_thread = Thread.new do
         Thread.current.abort_on_exception = true
@@ -38,11 +34,10 @@ module FileWatch
         Timeout.timeout(30) { sleep_started.pop }
       ensure
         watch.quit
-        sleep_release << true
       end
 
       expect(run_thread.join(30)).not_to be_nil
-      expect(sincedb_collection).to have_received(:flush_at_interval).once
+      expect(sincedb_collection).to have_received(:flush_at_interval).at_least(:once)
     end
   end
 end

--- a/spec/filewatch/watch_spec.rb
+++ b/spec/filewatch/watch_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'timeout'
 require_relative 'spec_helper'
 require 'filewatch/watch'
 
@@ -20,11 +21,27 @@ module FileWatch
 
     subject(:watch) { described_class.new(discoverer, processor, settings) }
 
-    it 'flushes sincedb after each sleep interval' do
-      allow(watch).to receive(:sleep) { watch.quit }
+    it 'flushes sincedb after a sleep interval' do
+      sleep_started = Queue.new
+      sleep_release = Queue.new
+      allow(watch).to receive(:sleep) do
+        sleep_started << true
+        sleep_release.pop
+      end
 
-      watch.subscribe(observer, sincedb_collection)
+      run_thread = Thread.new do
+        Thread.current.abort_on_exception = true
+        watch.subscribe(observer, sincedb_collection)
+      end
 
+      begin
+        Timeout.timeout(30) { sleep_started.pop }
+      ensure
+        watch.quit
+        sleep_release << true
+      end
+
+      expect(run_thread.join(30)).not_to be_nil
       expect(sincedb_collection).to have_received(:flush_at_interval).once
     end
   end

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -295,11 +295,17 @@ describe LogStash::Inputs::File do
     end
 
     let(:file_completions) { Queue.new }
+    let(:sincedb_flush_notifications) { Queue.new }
 
     let(:sample_file) { File.join(temp_directory, "sample.log") }
 
     before do
       plugin.register
+      allow_any_instance_of(FileWatch::SincedbCollection).to receive(:flush_at_interval).and_wrap_original do |original|
+        result = original.call
+        sincedb_flush_notifications << true
+        result
+      end
       allow(plugin).to receive(:handle_deletable_path).and_wrap_original do |original, path|
         original.call(path)
         file_completions << [path, File.exist?(path)]
@@ -331,16 +337,13 @@ describe LogStash::Inputs::File do
 
     context 'with sincedb cleanup enabled' do
       let(:options) do
-        super().merge(
-          'exit_after_read' => true,
-          'sincedb_clean_after' => '1 second',
-          'sincedb_write_interval' => 0
-        )
+        super().merge('sincedb_clean_after' => '1 second')
       end
+
+      around { |example| Timecop.freeze { example.run } }
 
       it 'cleans up sincedb entry' do
         wait_for_file_completion(sample_file)
-        expect(@run_thread.join(30)).not_to be_nil
 
         sincedb_collection = plugin.watcher.sincedb_collection
         expect(sincedb_collection.keys.size).to eq(1)
@@ -348,7 +351,12 @@ describe LogStash::Inputs::File do
         after_expiry = Time.at(sincedb_value.last_changed_at + 2)
 
         expect(File.read(options['sincedb_path'])).to_not be_empty
-        Timecop.freeze(after_expiry) { sincedb_collection.flush_at_interval }
+        Timecop.freeze(after_expiry) do
+          Timeout.timeout(30) do
+            # Wait for scheduled flushes until the expired entry is removed
+            sincedb_flush_notifications.pop until sincedb_collection.keys.empty?
+          end
+        end
 
         expect(sincedb_collection.keys).to be_empty
         expect(File.read(options['sincedb_path'])).to be_empty

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -293,24 +293,30 @@ describe LogStash::Inputs::File do
       super().merge({ 'file_completed_action' => "delete", 'exit_after_read' => false })
     end
 
+    let(:file_completions) { Queue.new }
+
     let(:sample_file) { File.join(temp_directory, "sample.log") }
 
     before do
       plugin.register
-      @run_thread = Thread.new(plugin) do |plugin|
-        Thread.current.abort_on_exception = true
-        plugin.run queue
+      completions = file_completions
+      allow(plugin).to receive(:handle_deletable_path).and_wrap_original do |original, path|
+        original.call(path)
+        completions << [path, File.exist?(path)]
       end
 
       File.open(sample_file, 'w') { |fd| fd.write("sample-content\n") }
 
-      wait_for_start_processing(@run_thread)
+      @run_thread = Thread.new(plugin) do |plugin|
+        Thread.current.abort_on_exception = true
+        plugin.run queue
+      end
     end
 
     after { plugin.stop }
 
     it 'processes a file' do
-      wait_for_file_removal(sample_file) # watched discovery
+      wait_for_file_completion(sample_file)
 
       expect( plugin.queue.size ).to eql 1
       event = plugin.queue.pop
@@ -318,78 +324,16 @@ describe LogStash::Inputs::File do
     end
 
     it 'removes watched file from collection' do
-      wait_for_file_removal(sample_file) # watched discovery
-      sleep(0.25) # give CI some space to execute the removal
-      # TODO shouldn't be necessary once WatchedFileCollection does proper locking
+      wait_for_file_completion(sample_file)
       watched_files = plugin.watcher.watch.watched_files_collection
       expect( watched_files ).to be_empty
     end
   end
 
-  describe 'sincedb cleanup' do
-
-    let(:options) do
-      super().merge(
-          'sincedb_path' => sincedb_path,
-          'sincedb_clean_after' => '1.0 seconds',
-          'sincedb_write_interval' => 0.25,
-          'stat_interval' => 0.1,
-      )
-    end
-
-    let(:sincedb_path) { "#{temp_directory}/.sincedb" }
-
-    let(:sample_file) { File.join(temp_directory, "sample.txt") }
-
-    before do
-      plugin.register
-      @run_thread = Thread.new(plugin) do |plugin|
-        Thread.current.abort_on_exception = true
-        plugin.run queue
-      end
-
-      File.open(sample_file, 'w') { |fd| fd.write("line1\nline2\n") }
-
-      wait_for_start_processing(@run_thread)
-    end
-
-    after { plugin.stop }
-
-    it 'cleans up sincedb entry' do
-      wait_for_file_removal(sample_file) # watched discovery
-
-      sincedb_content = File.read(sincedb_path).strip
-      expect( sincedb_content ).to_not be_empty
-
-      try(3) do
-        sleep(1.5) # > sincedb_clean_after
-
-        sincedb_content = File.read(sincedb_path).strip
-        expect( sincedb_content ).to be_empty
-      end
-    end
-
-  end
-
   private
 
-  def wait_for_start_processing(run_thread, timeout: 1.0)
-    begin
-      Timeout.timeout(timeout) do
-        sleep(0.01) while run_thread.status != 'sleep'
-        sleep(timeout) unless plugin.queue
-      end
-    rescue Timeout::Error
-      raise "plugin did not start processing (timeout: #{timeout})" unless plugin.queue
-    else
-      raise "plugin did not start processing" unless plugin.queue
-    end
-  end
-
-  def wait_for_file_removal(path)
-    timeout = interval
-    try(5) do
-      wait(timeout).for { File.exist?(path) }.to be_falsey
-    end
+  def wait_for_file_completion(path, timeout: 30)
+    completion = Timeout.timeout(timeout) { file_completions.pop }
+    expect(completion).to eq([path, false])
   end
 end

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -7,6 +7,7 @@ require "logstash/inputs/file"
 
 require "tempfile"
 require "stud/temporary"
+require "timecop"
 require "logstash/codecs/multiline"
 
 describe LogStash::Inputs::File do
@@ -326,6 +327,32 @@ describe LogStash::Inputs::File do
       wait_for_file_completion(sample_file)
       watched_files = plugin.watcher.watch.watched_files_collection
       expect( watched_files ).to be_empty
+    end
+
+    context 'with sincedb cleanup enabled' do
+      let(:options) do
+        super().merge(
+          'exit_after_read' => true,
+          'sincedb_clean_after' => '1 second',
+          'sincedb_write_interval' => 0
+        )
+      end
+
+      it 'cleans up sincedb entry' do
+        wait_for_file_completion(sample_file)
+        expect(@run_thread.join(30)).to equal(@run_thread)
+
+        sincedb_collection = plugin.watcher.sincedb_collection
+        expect(sincedb_collection.keys.size).to eq(1)
+        sincedb_value = sincedb_collection.get(sincedb_collection.keys.first)
+        after_expiry = Time.at(sincedb_value.last_changed_at + 2)
+
+        expect(File.read(options['sincedb_path'])).to_not be_empty
+        Timecop.freeze(after_expiry) { sincedb_collection.flush_at_interval }
+
+        expect(sincedb_collection.keys).to be_empty
+        expect(File.read(options['sincedb_path'])).to be_empty
+      end
     end
   end
 

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -340,7 +340,7 @@ describe LogStash::Inputs::File do
 
       it 'cleans up sincedb entry' do
         wait_for_file_completion(sample_file)
-        expect(@run_thread.join(30)).to equal(@run_thread)
+        expect(@run_thread.join(30)).not_to be_nil
 
         sincedb_collection = plugin.watcher.sincedb_collection
         expect(sincedb_collection.keys.size).to eq(1)

--- a/spec/inputs/file_read_spec.rb
+++ b/spec/inputs/file_read_spec.rb
@@ -299,10 +299,9 @@ describe LogStash::Inputs::File do
 
     before do
       plugin.register
-      completions = file_completions
       allow(plugin).to receive(:handle_deletable_path).and_wrap_original do |original, path|
         original.call(path)
-        completions << [path, File.exist?(path)]
+        file_completions << [path, File.exist?(path)]
       end
 
       File.open(sample_file, 'w') { |fd| fd.write("sample-content\n") }


### PR DESCRIPTION
## Summary

### Read-mode completion and sincedb cleanup

- synchronize read-mode completion specs with the deletion callback instead of polling filesystem state
- cover sincedb expiry at the collection boundary with deterministic timestamps
- verify that the watch loop invokes periodic sincedb cleanup without wall-clock delays

Affected CI runs for this group:

- https://github.com/logstash-plugins/logstash-input-file/actions/runs/31161528791
- https://github.com/logstash-plugins/logstash-input-file/actions/runs/31247901025
- https://github.com/logstash-plugins/logstash-input-file/actions/runs/31370470060

### Max-open-file tailing lifecycle

- synchronize max-open-file specs with listener notifications instead of fixed quit delays
- distinguish listener call history from cross-thread notifications in the test helper

Affected CI jobs for this group:

- https://github.com/logstash-plugins/logstash-input-file/actions/runs/31491753915/job/93779662401
